### PR TITLE
🐛 Update/fix Base class in models.py

### DIFF
--- a/dataservice/api/common/model.py
+++ b/dataservice/api/common/model.py
@@ -32,14 +32,14 @@ class HasFileMixin:
         return db.relationship("File")
 
 
-class Base(db.Model, IDMixin, TimestampMixin):
+class Base(IDMixin, TimestampMixin):
     """
     Defines base SQlAlchemy model class
     """
     pass
 
 
-class File(Base):
+class File(db.Model, Base):
     """
     Defines a file
     """

--- a/dataservice/api/person/models.py
+++ b/dataservice/api/person/models.py
@@ -2,7 +2,7 @@ from dataservice.extensions import db
 from dataservice.api.common.model import Base
 
 
-class Person(Base):
+class Person(db.Model, Base):
     """
     Person entity.
 


### PR DESCRIPTION
Change Base to inherit only the model mixins (Base should not inherit db.Model)

If Base inherits db.Model then this is saying that Base is a db.Model/a
sqlalchemy declarative base. sqlalchemy will think that we are trying to
do single table inheritance, which I don't believe we are. We just want
a class representing the common columns across entities.

Even if we were trying to do single table inheritance, then we need to add
additional code to all child classes of Base to instruct sqlalchemy on
how to handle two entity models with the same column names.

See link for more details:
http://docs.sqlalchemy.org/en/latest/orm/extensions/declarative/inheritance.html