### PR TITLE
🔧 Update sqlalchemy config w foreign key constraint for sqlite

### DIFF
--- a/dataservice/__init__.py
+++ b/dataservice/__init__.py
@@ -53,6 +53,17 @@ def register_extensions(app):
     # SQLAlchemy
     db.init_app(app)
 
+    # If using sqlite, must instruct sqlalchemy to set foreign key constraint
+    if app.config["SQLALCHEMY_DATABASE_URI"].startswith("sqlite"):
+        from sqlalchemy.engine import Engine
+        from sqlalchemy import event
+
+        @event.listens_for(Engine, "connect")
+        def set_sqlite_pragma(dbapi_connection, connection_record):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
+
     # Migrate
     migrate.init_app(app, db)
 


### PR DESCRIPTION
SQLite does not  enforce foreign key constraints by default. Need to explicitly tell sqlalchemy to turn on foreign key constraints when using sqlite.

Otherwise, tests to check foreign key constraints will fail (i.e. right now I can add a demographic for a person that does not exist)

See http://docs.sqlalchemy.org/en/latest/dialects/sqlite.html for more
details.