### PR TITLE
✨ Deserialize objects

### DIFF
--- a/dataservice/__init__.py
+++ b/dataservice/__init__.py
@@ -78,6 +78,7 @@ def register_error_handlers(app):
     from werkzeug.exceptions import HTTPException
     app.register_error_handler(HTTPException, errors.http_error)
     app.register_error_handler(404, errors.http_error)
+    app.register_error_handler(400, errors.http_error)
 
 
 def register_blueprints(app):

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -1,5 +1,5 @@
 from dataservice.extensions import ma
-from marshmallow import post_dump, post_load, validates_schema, ValidationError
+from marshmallow import post_dump, validates_schema, ValidationError
 from flask_marshmallow import Schema
 
 
@@ -16,7 +16,7 @@ class BaseSchema(ma.ModelSchema):
 
     @post_dump(pass_many=True)
     def wrap_envelope(self, data, many):
-        if type(data) is not list:
+        if not many and '_links' in data:
             _links = data['_links']
             del data['_links']
         else:

--- a/dataservice/api/participant/schemas.py
+++ b/dataservice/api/participant/schemas.py
@@ -1,14 +1,12 @@
 from dataservice.api.participant.models import Participant
 from dataservice.api.common.schemas import BaseSchema
 from dataservice.extensions import ma
-from marshmallow_sqlalchemy import field_for
 
 
 class ParticipantSchema(BaseSchema):
 
     class Meta(BaseSchema.Meta):
         model = Participant
-        dump_only = ('created_at', 'modified_at')
 
     _links = ma.Hyperlinks({
         'self': ma.URLFor('api.participants', kf_id='<kf_id>')

--- a/dataservice/api/participant/schemas.py
+++ b/dataservice/api/participant/schemas.py
@@ -1,13 +1,14 @@
 from dataservice.api.participant.models import Participant
 from dataservice.api.common.schemas import BaseSchema
 from dataservice.extensions import ma
+from marshmallow_sqlalchemy import field_for
 
 
 class ParticipantSchema(BaseSchema):
+
     class Meta(BaseSchema.Meta):
         model = Participant
-
-    date_created = ma.DateTime()
+        dump_only = ('created_at', 'modified_at')
 
     _links = ma.Hyperlinks({
         'self': ma.URLFor('api.participants', kf_id='<kf_id>')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,4 +10,5 @@ def client():
     app_context = app.app_context()
     app_context.push()
     db.create_all()
-    return app.test_client()
+    yield app.test_client()
+    db.drop_all()


### PR DESCRIPTION
Validate requests to create objects using Marshmallow's validation and deserialization. Now we get pretty feedback when the user does something stupid:

```
{
  "_status":{
    "code":400,
    "message":"could not create participant: {'blah': ['Unknown field']}"
  }
}
```

Addresses #69 