### PR TITLE
✨ Add pagination

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,6 +17,11 @@ class Config:
     SQLALCHEMY_DATABASE_URI = 'postgres://{}:{}@{}:{}/{}'.format(
                         PG_USER, PG_PASS, PG_HOST, PG_PORT, PG_NAME)
 
+    # Default number of results per request
+    DEFAULT_PAGE_SIZE = 10
+    # Determines the maximum number of results per request
+    MAX_PAGE_SIZE = 100
+
     @staticmethod
     def init_app(app):
         pass

--- a/config.py
+++ b/config.py
@@ -18,9 +18,9 @@ class Config:
                         PG_USER, PG_PASS, PG_HOST, PG_PORT, PG_NAME)
 
     # Default number of results per request
-    DEFAULT_PAGE_SIZE = 10
+    DEFAULT_PAGE_LIMIT = 10
     # Determines the maximum number of results per request
-    MAX_PAGE_SIZE = 100
+    MAX_PAGE_LIMIT = 100
 
     @staticmethod
     def init_app(app):

--- a/dataservice/api/README.md
+++ b/dataservice/api/README.md
@@ -19,27 +19,30 @@ Some examples:
 # Pagination
 
 Most resource containers are paginated and return 10 entries by default.
-Links to the next and previous page are provided in the `_links`.
+The dataservice uses the timestamp of the time of the object's creation
+to paginate. Specific dates may also be used. For example:
 
+```
+"/participants?after=01-12-2017",
+```
+Will list all participants created after December 1st, 2017.
+
+
+An example of the envelope wrapping a paginated response:
 ```json
 {
-  "_links": {
-    "next": "/participants?page=3",
-    "self": "/participants?page=2",
-    "prev": "/participants?page=1"
-  },
-  "_status": {
-    "code": 200,
-    "message": "OK"
-  }
-  "total": 1204,
-  "limit": 10,
-  "results": [
-    { "doc_id": 30, "value": "Lorem" },
-    { "doc_id": 31, "value": "ipsum" },
-    { "doc_id": 32, "value": "dolor" },
-    ...
-    { "doc_id": 40, "value": "amet" }
-  ],
+    "_links": {
+        "next": "/participants?after=1519220889.046443",
+        "self": "/participants?after=1519220889.035079"
+    },
+    "_status": {
+        "code": 200,
+        "message": "success"
+    },
+    "limit": 10,
+    "results": [
+      ...
+    ],
+    "total": 50
 }
 ```

--- a/dataservice/api/__init__.py
+++ b/dataservice/api/__init__.py
@@ -12,6 +12,8 @@ from dataservice.api.sample import SampleListAPI
 from dataservice.api.demographic import DemographicAPI
 from dataservice.api.demographic import DemographicListAPI
 
+from dataservice.api.study.models import Study
+
 
 api = Blueprint('api', __name__, url_prefix='', template_folder='templates')
 

--- a/dataservice/api/common/pagination.py
+++ b/dataservice/api/common/pagination.py
@@ -1,5 +1,7 @@
 from flask import request, current_app
 from functools import wraps
+from dateutil import parser
+from datetime import datetime
 
 
 def paginated(f):
@@ -9,7 +11,76 @@ def paginated(f):
         def_limit = current_app.config['DEFAULT_PAGE_LIMIT']
         max_limit = current_app.config['MAX_PAGE_LIMIT']
         limit = min(request.args.get('limit', def_limit, type=int), max_limit)
-        page = request.args.get('page', 1, type=int)
-        return f(*args, **kwargs, limit=limit, page=page)
+        after = request.args.get('after', None)
+
+        if type(after) is str:
+            # Parser won't recognize the timestamp with fractional seconds
+            if after.replace('.', '').isdigit():
+                after = float(after)
+                after = datetime.fromtimestamp(after)
+            else:
+                try:
+                    after = parser.parse(after)
+                # Parser couldn't derive a datetime from the string
+                except ValueError:
+                    after = None
+
+        # Default to the unix epoch
+        if after is None:
+            after = datetime.fromtimestamp(0)
+
+        return f(*args, **kwargs, after=after, limit=limit)
 
     return paginated_wrapper
+
+
+class Pagination(object):
+    """
+    Object to help paginate through endpoints using the created_at field
+    """
+
+    def __init__(self, query, after, limit):
+        assert type(after) is datetime
+        self.query = query
+        self.after = after
+        self.limit = limit
+        self.total = query.count()
+        # Assumes that we only provide queries for one entity
+        # This is safe as pagination only accesses one entity at a time
+        model = query._entities[0].mapper.entity
+        assert hasattr(model, 'created_at')
+        self.items = (query.order_by(model.created_at.asc())
+                           .filter(model.created_at > after)
+                           .limit(limit).all())
+
+    @property
+    def prev_num(self):
+        """ Returns the timestamp of the first item """
+        if len(self.items) > 0:
+            return self._to_timestamp(self.items[0].created_at)
+        return datetime.fromtimestamp(0)
+
+    @property
+    def curr_num(self):
+        """
+        Returns the timestamp of the first item minus some epsilon
+        so that the current timestamp will be included in the range
+        """
+        if len(self.items) > 0:
+            return self._to_timestamp(self.items[0].created_at) - 1/1000
+        return self._to_timestamp(datetime.utcnow())
+
+    @property
+    def next_num(self):
+        """ Returns the timestamp of the last item"""
+        if self.has_next:
+            return self._to_timestamp(self.items[-1].created_at)
+
+    @property
+    def has_next(self):
+        """ True if there are more than `limit` results """
+        return len(self.items) >= self.limit
+
+    def _to_timestamp(self, dt):
+        """ Converts a datetime object to milliseconds since epoch """
+        return dt.timestamp()

--- a/dataservice/api/common/pagination.py
+++ b/dataservice/api/common/pagination.py
@@ -6,9 +6,9 @@ def paginated(f):
 
     @wraps(f)
     def paginated_wrapper(*args, **kwargs):
-        def_size = current_app.config['DEFAULT_PAGE_SIZE']
-        max_size = current_app.config['MAX_PAGE_SIZE']
-        limit = min(request.args.get('size', def_size, type=int), max_size)
+        def_limit = current_app.config['DEFAULT_PAGE_LIMIT']
+        max_limit = current_app.config['MAX_PAGE_LIMIT']
+        limit = min(request.args.get('limit', def_limit, type=int), max_limit)
         page = request.args.get('page', 1, type=int)
         return f(*args, **kwargs, limit=limit, page=page)
 

--- a/dataservice/api/common/pagination.py
+++ b/dataservice/api/common/pagination.py
@@ -1,0 +1,15 @@
+from flask import request, current_app
+from functools import wraps
+
+
+def paginated(f):
+
+    @wraps(f)
+    def paginated_wrapper(*args, **kwargs):
+        def_size = current_app.config['DEFAULT_PAGE_SIZE']
+        max_size = current_app.config['MAX_PAGE_SIZE']
+        limit = min(request.args.get('size', def_size, type=int), max_size)
+        page = request.args.get('page', 1, type=int)
+        return f(*args, **kwargs, limit=limit, page=page)
+
+    return paginated_wrapper

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -28,10 +28,6 @@ class BaseSchema(ma.ModelSchema):
     def wrap_pre(self, data, many):
         if isinstance(data, Pagination):
             self.__pagination__ = data
-            if self.Meta.resource_url:
-                self._links = ma.Hyperlinks({
-                    'next': ma.URLFor(self.Meta.resource_url, kf_id='<kf_id>')
-                })
             return data.items
         return data
 

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -1,4 +1,5 @@
-from flask import abort, request
+from flask import abort, request, current_app
+from flask.views import MethodView
 from sqlalchemy.orm.exc import NoResultFound
 from marshmallow import ValidationError
 
@@ -16,7 +17,7 @@ class ParticipantListAPI(CRUDView):
     rule = '/participants'
     schemas = {'Participant': ParticipantSchema}
 
-    def get(self):
+    def get(self, limit, page):
         """
         Get a paginated participants
         ---
@@ -27,8 +28,10 @@ class ParticipantListAPI(CRUDView):
             resource:
               Participant
         """
+        q = Participant.query.order_by(Participant.created_at.desc())
+
         return (ParticipantSchema(many=True)
-                .jsonify(Participant.query.all()))
+                .jsonify(q.paginate(page, limit)))
 
     def post(self):
         """

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from marshmallow import ValidationError
 
 from dataservice.extensions import db
+from dataservice.api.common.pagination import paginated
 from dataservice.api.participant.models import Participant
 from dataservice.api.participant.schemas import ParticipantSchema
 from dataservice.api.common.views import CRUDView
@@ -17,6 +18,7 @@ class ParticipantListAPI(CRUDView):
     rule = '/participants'
     schemas = {'Participant': ParticipantSchema}
 
+    @paginated
     def get(self, limit, page):
         """
         Get a paginated participants

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -1,6 +1,7 @@
 from flask import abort, request, current_app
 from flask.views import MethodView
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.orm import joinedload
 from marshmallow import ValidationError
 
 from dataservice.extensions import db
@@ -30,7 +31,12 @@ class ParticipantListAPI(CRUDView):
             resource:
               Participant
         """
-        q = Participant.query
+        q = (Participant.query
+                        .options(joinedload(Participant.diagnoses))
+                        .options(joinedload(Participant.samples))
+                        .options(joinedload(Participant.phenotypes))
+                        .options(joinedload(Participant.demographic))
+                        .options(joinedload(Participant.outcomes)))
 
         return (ParticipantSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from marshmallow import ValidationError
 
 from dataservice.extensions import db
-from dataservice.api.common.pagination import paginated
+from dataservice.api.common.pagination import paginated, Pagination
 from dataservice.api.participant.models import Participant
 from dataservice.api.participant.schemas import ParticipantSchema
 from dataservice.api.common.views import CRUDView
@@ -19,7 +19,7 @@ class ParticipantListAPI(CRUDView):
     schemas = {'Participant': ParticipantSchema}
 
     @paginated
-    def get(self, limit, page):
+    def get(self, after, limit):
         """
         Get a paginated participants
         ---
@@ -30,10 +30,10 @@ class ParticipantListAPI(CRUDView):
             resource:
               Participant
         """
-        q = Participant.query.order_by(Participant.created_at.desc())
+        q = Participant.query
 
         return (ParticipantSchema(many=True)
-                .jsonify(q.paginate(page, limit)))
+                .jsonify(Pagination(q, after, limit)))
 
     def post(self):
         """

--- a/dataservice/api/participant/schemas.py
+++ b/dataservice/api/participant/schemas.py
@@ -16,7 +16,8 @@ class ParticipantSchema(BaseSchema):
 
     class Meta(BaseSchema.Meta):
         model = Participant
+        resource_url = 'api.participants_list'
 
     _links = ma.Hyperlinks({
-        'self': ma.URLFor('api.participants', kf_id='<kf_id>')
-    }, description='Resource links and pagination')
+        'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>')
+    })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ def app():
     return create_app('testing')
 
 
+@pytest.yield_fixture(scope='session')
+def app():
+    yield create_app('testing')
+
 @pytest.yield_fixture(scope='module')
 def client(app):
     app_context = app.app_context()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -74,7 +74,7 @@ class TestPagination:
         """ Test `after` offeset paramater """
         response = client.get(endpoint)
         response = json.loads(response.data.decode('utf-8'))
-        first = response['_links']['self']
+        first = response['results'][0]['created_at']
 
         # Check unexpected after param returns the earliest
         response = client.get(endpoint+'?after=dog')

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,76 @@
+import json
+import pytest
+
+from dataservice.extensions import db
+from dataservice.api.participant.models import Participant
+from dataservice.api.study.models import Study
+
+
+class TestPagination:
+    """
+    """
+
+
+    @pytest.fixture
+    def participants(client):
+        s = Study(external_id='blah', name='test')
+        db.session.add(s)
+        db.session.flush()
+        for i in range(102):
+            p = Participant(external_id="test", study_id=s.kf_id)
+            db.session.add(p)
+        db.session.commit()
+
+    @pytest.mark.parametrize('endpoint', [
+        ('/participants'),
+    ])
+    def test_pagination(self, client, participants, endpoint):
+        """ Test pagination of resource """
+        response = client.get(endpoint)
+        response =  json.loads(response.data)
+        
+        assert len(response['results']) == 10
+        assert response['limit'] == 10
+        assert response['total'] == 102
+
+        # Check that size param operates correctly
+        response = client.get(endpoint+'?size=5')
+        response =  json.loads(response.data)
+        assert len(response['results']) == 5
+        assert response['limit'] == 5
+
+        response = client.get(endpoint+'?size=200')
+        response =  json.loads(response.data)
+        assert len(response['results']) == 100
+
+        # Check unexpected size param uses default
+        response = client.get(endpoint+'?size=dog')
+        response =  json.loads(response.data)
+        assert len(response['results']) == 10
+        assert response['limit'] == 10
+
+        # Check that page param operates correctly
+        response = client.get(endpoint)
+        response =  json.loads(response.data)
+        assert response['page'] == 1
+
+        response = client.get(endpoint+'?page=5')
+        response =  json.loads(response.data)
+        assert response['page'] == 5
+        assert response['_links']['next'].endswith('?page=6')
+        assert response['_links']['prev'].endswith('?page=4')
+        assert response['_links']['self'].endswith('?page=5')
+
+        # Check unexpected page param returns page 1 
+        response = client.get(endpoint+'?page=dog')
+        response =  json.loads(response.data)
+        assert response['_links']['self'].endswith('?page=1')
+
+        response = client.get(endpoint+'?size=2')
+        response =  json.loads(response.data)
+
+        # Check unexpected page param returns page 1 
+        response = client.get(endpoint+'?page=1000')
+        assert response.status_code == 404
+        response =  json.loads(response.data)
+        assert response['_status']['code'] == 404

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -33,18 +33,18 @@ class TestPagination:
         assert response['limit'] == 10
         assert response['total'] == 102
 
-        # Check that size param operates correctly
-        response = client.get(endpoint+'?size=5')
+        # Check that limit param operates correctly
+        response = client.get(endpoint+'?limit=5')
         response =  json.loads(response.data)
         assert len(response['results']) == 5
         assert response['limit'] == 5
 
-        response = client.get(endpoint+'?size=200')
+        response = client.get(endpoint+'?limit=200')
         response =  json.loads(response.data)
         assert len(response['results']) == 100
 
-        # Check unexpected size param uses default
-        response = client.get(endpoint+'?size=dog')
+        # Check unexpected limit param uses default
+        response = client.get(endpoint+'?limit=dog')
         response =  json.loads(response.data)
         assert len(response['results']) == 10
         assert response['limit'] == 10
@@ -66,7 +66,7 @@ class TestPagination:
         response =  json.loads(response.data)
         assert response['_links']['self'].endswith('?page=1')
 
-        response = client.get(endpoint+'?size=2')
+        response = client.get(endpoint+'?limit=2')
         response =  json.loads(response.data)
 
         # Check unexpected page param returns page 1 


### PR DESCRIPTION
Uses the `created_at` timestamp to paginate through participants.
Can also use anything that may be parsed into a `datetime` by `dateutil.parser`.
Eg: `/participants?after=01-01-2017`

Other additions that could be made:

- Allow reverse iteration with a `?before=` (from newest to oldest)
- Add an index to the `created_at` column in pg to speed up filtering


Resolves #12 