### PR TITLE
🐛 Fix self links

### DIFF
--- a/dataservice/api/common/pagination.py
+++ b/dataservice/api/common/pagination.py
@@ -67,7 +67,7 @@ class Pagination(object):
         so that the current timestamp will be included in the range
         """
         if len(self.items) > 0:
-            return self._to_timestamp(self.items[0].created_at) - 1/1000
+            return self._to_timestamp(self.items[0].created_at) - 1/100000
         return self._to_timestamp(datetime.utcnow())
 
     @property

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -55,7 +55,7 @@ class BaseSchema(ma.ModelSchema):
             _links = {}
 
             # If an 'after' param could not be parsed, don't include the param
-            after = None if p.after.timestamp() == 0 else p.after
+            after = None if p.after.timestamp() == 0 else p.curr_num
             _links['self'] = url_for(self.Meta.resource_url,
                                      after=after)
             if p.has_next:


### PR DESCRIPTION
- Fixes formatting of the `self` link where a datetime was being used instead of a timestamp.
- Fixes issue where the timestamp being returned for the current page did not have a small enough delta causing earlier results to be  returned.