### PR TITLE
✨ ⚡️Change PUT to PATCH in all resource APIs and minor updates

### DIFF
--- a/dataservice/__init__.py
+++ b/dataservice/__init__.py
@@ -121,6 +121,7 @@ def register_error_handlers(app):
     from dataservice.api import errors
     app.register_error_handler(HTTPException, errors.http_error)
     app.register_error_handler(IntegrityError, errors.integrity_error)
+    app.register_error_handler(405, errors.http_error)
     app.register_error_handler(404, errors.http_error)
     app.register_error_handler(400, errors.http_error)
 

--- a/dataservice/__init__.py
+++ b/dataservice/__init__.py
@@ -23,7 +23,6 @@ from dataservice.api.study_file.models import StudyFile
 from config import config
 
 from sqlalchemy.exc import IntegrityError
-from werkzeug.exceptions import HTTPException
 
 
 def create_app(config_name):
@@ -119,11 +118,10 @@ def register_error_handlers(app):
     NB: Exceptions to be handled must be imported in the head of this module
     """
     from dataservice.api import errors
-    app.register_error_handler(HTTPException, errors.http_error)
     app.register_error_handler(IntegrityError, errors.integrity_error)
-    app.register_error_handler(405, errors.http_error)
-    app.register_error_handler(404, errors.http_error)
-    app.register_error_handler(400, errors.http_error)
+    from werkzeug.exceptions import default_exceptions
+    for ex in default_exceptions:
+        app.register_error_handler(ex, errors.http_error)
 
 
 def register_blueprints(app):

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -1,12 +1,12 @@
 from dataservice.extensions import ma
 from marshmallow import (
-        fields,
-        post_dump,
-        pre_dump,
-        validates_schema,
-        ValidationError
+    fields,
+    post_dump,
+    pre_dump,
+    validates_schema,
+    ValidationError
 )
-from flask import url_for, request
+from flask import url_for
 from dataservice.api.common.pagination import Pagination
 from flask_marshmallow import Schema
 
@@ -120,8 +120,8 @@ class StatusSchema(Schema):
     commit = fields.Str(description='API short commit hash', example='aef3b5a')
     branch = fields.Str(description='API branch name', example='master')
     tags = fields.List(
-            fields.String(description='Any tags associated with the version',
-                          example=['rc', 'beta']))
+        fields.String(description='Any tags associated with the version',
+                      example=['rc', 'beta']))
 
     @post_dump(pass_many=False)
     def wrap_envelope(self, data):

--- a/dataservice/api/common/views.py
+++ b/dataservice/api/common/views.py
@@ -1,7 +1,6 @@
 import yaml
 import jinja2
 from flask.views import MethodView
-from flask import render_template
 from dataservice.api.common.schemas import (
     response_generator,
     paginated_generator
@@ -42,9 +41,9 @@ class CRUDView(MethodView):
             for name, schema in c.schemas.items():
                 spec.definition(name, schema=schema)
                 ResponseSchema = response_generator(schema)
-                spec.definition(name+'Response', schema=ResponseSchema)
+                spec.definition(name + 'Response', schema=ResponseSchema)
                 PaginatedSchema = paginated_generator(schema)
-                spec.definition(name+'Paginated', schema=PaginatedSchema)
+                spec.definition(name + 'Paginated', schema=PaginatedSchema)
 
     @staticmethod
     def register_views(app):
@@ -80,7 +79,7 @@ class CRUDView(MethodView):
         # No yaml section
         if yaml_start == -1:
             return
-        yaml_spec = yaml.safe_load(func.__doc__[yaml_start+3:])
+        yaml_spec = yaml.safe_load(func.__doc__[yaml_start + 3:])
 
         # No template to insert
         if 'template' not in yaml_spec:
@@ -95,7 +94,7 @@ class CRUDView(MethodView):
         templated_spec.update(yaml_spec)
 
         # Dump the deserialized spec back to yaml in the docstring
-        func.__doc__ = func.__doc__[:yaml_start+4]
+        func.__doc__ = func.__doc__[:yaml_start + 4]
         func.__doc__ += yaml.dump(templated_spec, default_flow_style=False)
         # The docstring is now ready for further processing by apispec
 

--- a/dataservice/api/demographic/resources.py
+++ b/dataservice/api/demographic/resources.py
@@ -82,17 +82,12 @@ class DemographicAPI(CRUDView):
             resource:
               Demographic
         """
-        # Get all
-        if kf_id is None:
-            dm = Demographic.query.all()
-            return DemographicSchema(many=True).jsonify(dm)
-        # Get one
-        else:
-            dm = Demographic.query.get(kf_id)
-            if dm is None:
-                abort(404, 'could not find {} `{}`'
-                      .format('demographic', kf_id))
-            return DemographicSchema().jsonify(dm)
+        dm = Demographic.query.get(kf_id)
+        if dm is None:
+            abort(404, 'could not find {} `{}`'
+                  .format('demographic', kf_id))
+
+        return DemographicSchema().jsonify(dm)
 
     def patch(self, kf_id):
         """

--- a/dataservice/api/demographic/schemas.py
+++ b/dataservice/api/demographic/schemas.py
@@ -5,11 +5,6 @@ from dataservice.extensions import ma
 
 
 class DemographicSchema(BaseSchema):
-    # Should not have to do this, since participant_id is part of the
-    # Demographic model and should be dumped. However it looks like this is
-    # still a bug in marshmallow_sqlalchemy. The bug is that ma sets
-    # dump_only=True for foreign keys by default. See link below
-    # https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/20
     participant_id = field_for(Demographic, 'participant_id', required=True,
                                load_only=True)
 

--- a/dataservice/api/diagnosis/schemas.py
+++ b/dataservice/api/diagnosis/schemas.py
@@ -1,5 +1,4 @@
 from marshmallow_sqlalchemy import field_for
-from marshmallow import validates, ValidationError
 
 from dataservice.api.diagnosis.models import Diagnosis
 from dataservice.api.common.schemas import BaseSchema
@@ -8,11 +7,6 @@ from dataservice.extensions import ma
 
 
 class DiagnosisSchema(BaseSchema):
-    # Should not have to do this, since participant_id is part of the
-    # Diagnosis model and should be dumped. However it looks like this is
-    # still a bug in marshmallow_sqlalchemy. The bug is that ma sets
-    # dump_only=True for foreign keys by default. See link below
-    # https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/20
     participant_id = field_for(Diagnosis, 'participant_id', required=True,
                                load_only=True, example='DZB048J5')
     age_at_event_days = field_for(Diagnosis, 'age_at_event_days',

--- a/dataservice/api/docs/resources.py
+++ b/dataservice/api/docs/resources.py
@@ -1,6 +1,4 @@
-import os
 import glob
-import subprocess
 from flask.views import View
 from flask import jsonify, current_app, render_template
 

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -1,4 +1,3 @@
-from pprint import pprint
 from flask import abort, request
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm import joinedload
@@ -87,7 +86,7 @@ class ParticipantAPI(CRUDView):
             participant = Participant.query.filter_by(kf_id=kf_id).one()
         except NoResultFound:
             abort(404, 'could not find {} `{}`'
-                  .format('Participant', kf_id))
+                  .format('participant', kf_id))
         return ParticipantSchema().jsonify(participant)
 
     def patch(self, kf_id):
@@ -106,7 +105,7 @@ class ParticipantAPI(CRUDView):
             p = Participant.query.filter_by(kf_id=kf_id).one()
         except NoResultFound:
             abort(404, 'could not find {} `{}`'
-                  .format('Participant', kf_id))
+                  .format('participant', kf_id))
 
         # Partial update - validate but allow missing required fields
         try:
@@ -136,7 +135,7 @@ class ParticipantAPI(CRUDView):
         try:
             p = Participant.query.filter_by(kf_id=kf_id).one()
         except NoResultFound:
-            abort(404, 'could not find {} `{}`'.format('Participant', kf_id))
+            abort(404, 'could not find {} `{}`'.format('participant', kf_id))
 
         db.session.delete(p)
         db.session.commit()

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -1,5 +1,5 @@
-from flask import abort, request, current_app
-from flask.views import MethodView
+from pprint import pprint
+from flask import abort, request
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm import joinedload
 from marshmallow import ValidationError
@@ -90,9 +90,9 @@ class ParticipantAPI(CRUDView):
                   .format('Participant', kf_id))
         return ParticipantSchema().jsonify(participant)
 
-    def put(self, kf_id):
+    def patch(self, kf_id):
         """
-        Update an existing participant
+        Update an existing participant. Allows partial update
         ---
         template:
           path:
@@ -101,23 +101,26 @@ class ParticipantAPI(CRUDView):
             resource:
               Participant
         """
-        body = request.json
+        body = request.json or {}
         try:
             p = Participant.query.filter_by(kf_id=kf_id).one()
         except NoResultFound:
             abort(404, 'could not find {} `{}`'
                   .format('Participant', kf_id))
 
-        p.external_id = body.get('external_id')
-        p.family_id = body.get('family_id')
-        p.is_proband = body.get('is_proband')
-        p.consent_type = body.get('consent_type')
-        p.study_id = body.get('study_id')
+        # Partial update - validate but allow missing required fields
+        try:
+            p = ParticipantSchema(strict=True).load(body, instance=p,
+                                                    partial=True).data
+        except ValidationError as err:
+            abort(400, 'could not update participant: {}'.format(err.messages))
+
+        db.session.add(p)
         db.session.commit()
 
         return ParticipantSchema(
-            201, 'participant {} updated'.format(p.kf_id)
-        ).jsonify(p), 201
+            200, 'participant {} updated'.format(p.kf_id)
+        ).jsonify(p), 200
 
     def delete(self, kf_id):
         """

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -1,5 +1,4 @@
 from flask import abort, request
-from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm import joinedload
 from marshmallow import ValidationError
 
@@ -82,12 +81,12 @@ class ParticipantAPI(CRUDView):
             resource:
               Participant
         """
-        try:
-            participant = Participant.query.filter_by(kf_id=kf_id).one()
-        except NoResultFound:
+        p = Participant.query.get(kf_id)
+        if p is None:
             abort(404, 'could not find {} `{}`'
                   .format('participant', kf_id))
-        return ParticipantSchema().jsonify(participant)
+
+        return ParticipantSchema().jsonify(p)
 
     def patch(self, kf_id):
         """
@@ -100,14 +99,13 @@ class ParticipantAPI(CRUDView):
             resource:
               Participant
         """
-        body = request.json or {}
-        try:
-            p = Participant.query.filter_by(kf_id=kf_id).one()
-        except NoResultFound:
+        p = Participant.query.get(kf_id)
+        if p is None:
             abort(404, 'could not find {} `{}`'
                   .format('participant', kf_id))
 
         # Partial update - validate but allow missing required fields
+        body = request.json or {}
         try:
             p = ParticipantSchema(strict=True).load(body, instance=p,
                                                     partial=True).data
@@ -132,10 +130,10 @@ class ParticipantAPI(CRUDView):
             resource:
               Participant
         """
-        try:
-            p = Participant.query.filter_by(kf_id=kf_id).one()
-        except NoResultFound:
-            abort(404, 'could not find {} `{}`'.format('participant', kf_id))
+        p = Participant.query.get(kf_id)
+        if p is None:
+            abort(404, 'could not find {} `{}`'
+                  .format('participant', kf_id))
 
         db.session.delete(p)
         db.session.commit()

--- a/dataservice/api/sample/resources.py
+++ b/dataservice/api/sample/resources.py
@@ -91,11 +91,9 @@ class SampleAPI(CRUDView):
                   .format('sample', kf_id))
         return SampleSchema().jsonify(s)
 
-    def put(self, kf_id):
+    def patch(self, kf_id):
         """
-        Update existing sample
-
-        Update an existing sample given a Kids First id
+        Update an existing sample. Allows partial update of resource
         ---
         template:
           path:
@@ -104,37 +102,26 @@ class SampleAPI(CRUDView):
             resource:
               Sample
         """
-        body = request.json
-
-        # Check if sample exists
+        body = request.json or {}
         try:
-            s1 = Sample.query.filter_by(kf_id=kf_id).one()
-        # Not found in database
+            dg = Sample.query.filter_by(kf_id=kf_id).one()
         except NoResultFound:
-            abort(404, 'could not find {} `{}`'.format('sample', kf_id))
+            abort(404, 'could not find {} `{}`'
+                  .format('sample', kf_id))
 
-        # Validation only
+        # Partial update - validate but allow missing required fields
         try:
-            s = SampleSchema(strict=True).load(body).data
-        # Request body not valid
-        except ValidationError as e:
-            abort(400, 'could not update sample: {}'.format(e.messages))
+            dg = SampleSchema(strict=True).load(body, instance=dg,
+                                                partial=True).data
+        except ValidationError as err:
+            abort(400, 'could not update sample: {}'.format(err.messages))
 
-        # Deserialize
-        s1.external_id = body.get('external_id')
-        s1.tissue_type = body.get('tissue_type')
-        s1.composition = body.get('composition')
-        s1.anatomical_site = body.get('anatomical_site')
-        s1.tumor_descriptor = body.get('tumor_descriptor')
-        s1.aliquots = body.get('aliquots', [])
-        s1.age_at_event_days = body.get('age_at_event_days')
-        s1.participant_id = body.get('participant_id')
-
-        # Save to database
+        db.session.add(dg)
         db.session.commit()
 
-        return SampleSchema(200, 'sample {} updated'
-                            .format(s1.kf_id)).jsonify(s1), 200
+        return SampleSchema(
+            200, 'sample {} updated'.format(dg.kf_id)
+        ).jsonify(dg), 200
 
     def delete(self, kf_id):
         """

--- a/dataservice/api/sample/schemas.py
+++ b/dataservice/api/sample/schemas.py
@@ -7,11 +7,6 @@ from dataservice.extensions import ma
 
 
 class SampleSchema(BaseSchema):
-    # Should not have to do this, since participant_id is part of the
-    # Sample model and should be dumped. However it looks like this is
-    # still a bug in marshmallow_sqlalchemy. The bug is that ma sets
-    # dump_only=True for foreign keys by default. See link below
-    # https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/20
     participant_id = field_for(Sample, 'participant_id', required=True,
                                load_only=True)
     age_at_event_days = field_for(Sample, 'age_at_event_days',

--- a/dataservice/api/templates/update_by_id.yml
+++ b/dataservice/api/templates/update_by_id.yml
@@ -1,4 +1,4 @@
-description: Update a {{ resource.lower() }}
+description: Partial update of a {{ resource.lower() }}
 tags:
 - {{ resource }}
 parameters:

--- a/dataservice/extensions.py
+++ b/dataservice/extensions.py
@@ -1,5 +1,5 @@
 from flask_migrate import Migrate
-from flask_sqlalchemy import SQLAlchemy, Model
+from flask_sqlalchemy import SQLAlchemy
 from flask_marshmallow import Marshmallow
 
 db = SQLAlchemy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,5 +102,6 @@ def entities(client):
     # Add kf_ids
     inputs['kf_ids'] = {'/participants': p.kf_id}
     inputs['kf_ids'].update({'/demographics': p.demographic.kf_id})
+    inputs['kf_ids'].update({'/diagnoses': diagnosis.kf_id})
 
     return inputs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,5 +103,6 @@ def entities(client):
     inputs['kf_ids'] = {'/participants': p.kf_id}
     inputs['kf_ids'].update({'/demographics': p.demographic.kf_id})
     inputs['kf_ids'].update({'/diagnoses': diagnosis.kf_id})
+    inputs['kf_ids'].update({'/samples': sample.kf_id})
 
     return inputs

--- a/tests/demographic/test_demographic_resources.py
+++ b/tests/demographic/test_demographic_resources.py
@@ -215,7 +215,6 @@ class DemographicTest(FlaskTestCase):
 
         # Message
         resp = json.loads(response.data.decode("utf-8"))
-        self._test_response_content(resp, 200)
         self.assertIn('demographic', resp['_status']['message'])
         self.assertIn('updated', resp['_status']['message'])
 
@@ -334,12 +333,3 @@ class DemographicTest(FlaskTestCase):
         kwargs['kf_id'] = d.kf_id
 
         return kwargs
-
-    def _test_response_content(self, resp, status_code):
-        """
-        Test that response body has expected fields
-        """
-        self.assertIn('results', resp)
-        self.assertIn('_status', resp)
-        self.assertIn('message', resp['_status'])
-        self.assertEqual(resp['_status']['code'], status_code)

--- a/tests/demographic/test_demographic_resources.py
+++ b/tests/demographic/test_demographic_resources.py
@@ -1,5 +1,7 @@
 import json
 from flask import url_for
+from datetime import datetime
+from dateutil import parser, tz
 from urllib.parse import urlparse
 
 from dataservice.extensions import db
@@ -26,7 +28,7 @@ class DemographicTest(FlaskTestCase):
         db.session.add(study)
         db.session.commit()
 
-        # Create a participant
+        # Create a demographic
         p = Participant(external_id='Test subject 0', is_proband=True,
                         study_id=study.kf_id)
         db.session.add(p)
@@ -47,13 +49,15 @@ class DemographicTest(FlaskTestCase):
 
         # Check response status status_code
         self.assertEqual(response.status_code, 201)
+
         # Check response content
         response = json.loads(response.data.decode('utf-8'))
         demographic = response['results']
-        self.assertEqual(kwargs['external_id'], demographic['external_id'])
-        self.assertEqual(kwargs['race'], demographic['race'])
-        self.assertEqual(kwargs['ethnicity'], demographic['ethnicity'])
-        self.assertEqual(kwargs['gender'], demographic['gender'])
+        dm = Demographic.query.get(demographic.get('kf_id'))
+        for k, v in kwargs.items():
+            if k == 'participant_id':
+                continue
+            self.assertEqual(demographic[k], getattr(dm, k))
 
     def test_post_missing_req_params(self):
         """
@@ -190,117 +194,78 @@ class DemographicTest(FlaskTestCase):
         content = response.get('results')
         self.assertEqual(len(content), 1)
 
-    def test_put(self):
+    def test_patch(self):
         """
         Test update existing demographic
         """
+        # Send patch request
         kwargs = self._create_save_to_db()
-
-        # Send put request
+        kf_id = kwargs.get('kf_id')
         body = {
             'race': 'black or african',
             'gender': 'male',
             'participant_id': kwargs['participant_id']
         }
-        response = self.client.put(url_for(DEMOGRAPHICS_URL,
-                                           kf_id=kwargs['kf_id']),
-                                   headers=self._api_headers(),
-                                   data=json.dumps(body))
+        response = self.client.patch(url_for(DEMOGRAPHICS_URL,
+                                             kf_id=kf_id),
+                                     headers=self._api_headers(),
+                                     data=json.dumps(body))
         # Check status code
         self.assertEqual(response.status_code, 200)
-        # Check field values got updated
-        response = json.loads(response.data.decode('utf-8'))
-        demographic = response['results']
-        self.assertEqual(kwargs['kf_id'], demographic['kf_id'])
-        # Fields that should be None since they were not in put request body
-        self.assertIs(None, demographic['external_id'])
-        self.assertIs(None, demographic['ethnicity'])
-        # Fields that should be updated w values
-        self.assertEqual(body['race'], demographic['race'])
-        self.assertEqual(body['gender'], demographic['gender'])
 
-    def test_put_not_found(self):
-        """
-        Test update non-existent demographic
-        """
-        # Send put request
-        kf_id = 'non-existent'
-        body = {
-            'race': 'black or african',
-            'gender': 'male',
-            'participant_id': id_service.kf_id_generator('PT')()
-        }
-        response = self.client.put(url_for(DEMOGRAPHICS_URL,
-                                           kf_id=kf_id),
-                                   headers=self._api_headers(),
-                                   data=json.dumps(body))
-        # Check status code
-        self.assertEqual(response.status_code, 404)
-        # Check response body
-        response = json.loads(response.data.decode("utf-8"))
-        # Check error message
-        message = 'could not find demographic'
-        self.assertIn(message, response['_status']['message'])
-        # Check database
-        c = Demographic.query.filter_by(kf_id=kf_id).count()
-        self.assertEqual(c, 0)
+        # Message
+        resp = json.loads(response.data.decode("utf-8"))
+        self._test_response_content(resp, 200)
+        self.assertIn('demographic', resp['_status']['message'])
+        self.assertIn('updated', resp['_status']['message'])
 
-    def test_put_bad_input(self):
-        """
-        Test update existing demographic with bad input
+        # Content - check only patched fields are updated
+        demographic = resp['results']
+        dm = Demographic.query.get(kf_id)
+        for k, v in body.items():
+            self.assertEqual(v, getattr(dm, k))
 
-        Participant with participant_id does not exist
+        # Content - Check remaining fields are unchanged
+        unchanged_keys = (set(demographic.keys()) -
+                          set(body.keys()))
+        for k in unchanged_keys:
+            val = getattr(dm, k)
+            if isinstance(val, datetime):
+                d = val.replace(tzinfo=tz.tzutc())
+                self.assertEqual(str(parser.parse(demographic[k])), str(d))
+            else:
+                self.assertEqual(demographic[k], val)
+
+        self.assertEqual(1, Demographic.query.count())
+
+    def test_patch_bad_input(self):
         """
-        # Create and save demographic to db
+        Test updating an existing participant with invalid input
+        """
         kwargs = self._create_save_to_db()
-
-        # Send put request
+        kf_id = kwargs.get('kf_id')
         body = {
             'race': 'black or african',
             'gender': 'male',
             'participant_id': 'AAAA1111'
         }
-        response = self.client.put(url_for(DEMOGRAPHICS_URL,
-                                           kf_id=kwargs['kf_id']),
-                                   headers=self._api_headers(),
-                                   data=json.dumps(body))
+        response = self.client.patch(url_for(DEMOGRAPHICS_URL,
+                                             kf_id=kf_id),
+                                     headers=self._api_headers(),
+                                     data=json.dumps(body))
         # Check status code
         self.assertEqual(response.status_code, 400)
         # Check response body
         response = json.loads(response.data.decode("utf-8"))
         # Check error message
-        message = '"AAAA1111" does not exist'
+        message = 'participant "AAAA1111" does not exist'
         self.assertIn(message, response['_status']['message'])
-        # Check field values
+        # Check that properties are unchanged
         d = Demographic.query.first()
-        self.assertEqual(d.race, kwargs.get('race'))
-        self.assertEqual(d.gender, kwargs.get('gender'))
-
-    def test_put_missing_req_params(self):
-        """
-        Test create demographic that is missing required parameters in body
-        """
-        # Create and save demographic to db
-        kwargs = self._create_save_to_db()
-        # Create demographic data
-        body = {
-            'gender': 'male'
-        }
-        # Send put request
-        response = self.client.put(url_for(DEMOGRAPHICS_URL,
-                                           kf_id=kwargs['kf_id']),
-                                   headers=self._api_headers(),
-                                   data=json.dumps(body))
-        # Check status code
-        self.assertEqual(response.status_code, 400)
-        # Check response body
-        response = json.loads(response.data.decode("utf-8"))
-        # Check error message
-        message = 'could not update demographic'
-        self.assertIn(message, response['_status']['message'])
-        # Check field values
-        d = Demographic.query.first()
-        self.assertEqual(d.gender, kwargs['gender'])
+        for k, v in kwargs.items():
+            if k == 'participant_id':
+                continue
+            self.assertEqual(v, getattr(d, k))
 
     def test_delete(self):
         """
@@ -369,3 +334,12 @@ class DemographicTest(FlaskTestCase):
         kwargs['kf_id'] = d.kf_id
 
         return kwargs
+
+    def _test_response_content(self, resp, status_code):
+        """
+        Test that response body has expected fields
+        """
+        self.assertIn('results', resp)
+        self.assertIn('_status', resp)
+        self.assertIn('message', resp['_status'])
+        self.assertEqual(resp['_status']['code'], status_code)

--- a/tests/diagnosis/test_diagnosis_resources.py
+++ b/tests/diagnosis/test_diagnosis_resources.py
@@ -26,14 +26,7 @@ class DiagnosisTest(FlaskTestCase):
         """
         Test create a new diagnosis
         """
-        # Create study
-        study = Study(external_id='phs001')
-
-        # Create a participant
-        p = Participant(external_id='Test subject 0', is_proband=True,
-                        study=study)
-        db.session.add(p)
-        db.session.commit()
+        kwargs = self._create_save_to_db()
 
         # Create diagnosis data
         kwargs = {
@@ -42,7 +35,7 @@ class DiagnosisTest(FlaskTestCase):
             'age_at_event_days': 365,
             'diagnosis_category': 'cancer',
             'tumor_location': 'Brain',
-            'participant_id': p.kf_id
+            'participant_id': kwargs.get('participant_id')
         }
         # Send get request
         response = self.client.post(url_for(DIAGNOSES_LIST_URL),
@@ -60,6 +53,7 @@ class DiagnosisTest(FlaskTestCase):
             if k == 'participant_id':
                 continue
             self.assertEqual(diagnosis[k], getattr(dg, k))
+        self.assertEqual(2, Diagnosis.query.count())
 
     def test_post_missing_req_params(self):
         """

--- a/tests/diagnosis/test_diagnosis_resources.py
+++ b/tests/diagnosis/test_diagnosis_resources.py
@@ -14,8 +14,6 @@ from tests.utils import FlaskTestCase
 DIAGNOSES_URL = 'api.diagnoses'
 DIAGNOSES_LIST_URL = 'api.diagnoses_list'
 
-from pprint import pprint
-
 
 class DiagnosisTest(FlaskTestCase):
     """

--- a/tests/participant/test_participant_resources.py
+++ b/tests/participant/test_participant_resources.py
@@ -26,7 +26,6 @@ class ParticipantTest(FlaskTestCase):
         resp = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 201)
-        self._test_response_content(resp, 201)
 
         self.assertIn('participant', resp['_status']['message'])
         self.assertIn('created', resp['_status']['message'])
@@ -77,7 +76,6 @@ class ParticipantTest(FlaskTestCase):
                                    headers=self._api_headers())
         resp = json.loads(response.data.decode("utf-8"))
         self.assertEqual(response.status_code, 200)
-        self._test_response_content(resp, 200)
 
         participant = resp['results']
         p = Participant.query.first()
@@ -123,7 +121,6 @@ class ParticipantTest(FlaskTestCase):
 
         # Message
         resp = json.loads(response.data.decode("utf-8"))
-        self._test_response_content(resp, 200)
         self.assertIn('participant', resp['_status']['message'])
         self.assertIn('updated', resp['_status']['message'])
 
@@ -221,12 +218,3 @@ class ParticipantTest(FlaskTestCase):
                                     headers=self._api_headers(),
                                     data=json.dumps(body))
         return response
-
-    def _test_response_content(self, resp, status_code):
-        """
-        Test that response body has expected fields
-        """
-        self.assertIn('results', resp)
-        self.assertIn('_status', resp)
-        self.assertIn('message', resp['_status'])
-        self.assertEqual(resp['_status']['code'], status_code)

--- a/tests/participant/test_participant_resources.py
+++ b/tests/participant/test_participant_resources.py
@@ -1,5 +1,4 @@
 import json
-from pprint import pprint
 from datetime import datetime
 from dateutil import parser, tz
 

--- a/tests/sample/test_sample_resources.py
+++ b/tests/sample/test_sample_resources.py
@@ -25,15 +25,7 @@ class SampleTest(FlaskTestCase):
         """
         Test create a new sample
         """
-        study = Study(external_id='phs001')
-        db.session.add(study)
-        db.session.commit()
-
-        # Create a participant
-        p = Participant(external_id='Test subject 0',
-                        is_proband=True, study_id=study.kf_id)
-        db.session.add(p)
-        db.session.commit()
+        kwargs = self._create_save_to_db()
 
         # Create sample data
         kwargs = {
@@ -43,7 +35,7 @@ class SampleTest(FlaskTestCase):
             'anatomical_site': 'Brain',
             'age_at_event_days': 365,
             'tumor_descriptor': 'Metastatic',
-            'participant_id': p.kf_id
+            'participant_id': kwargs.get('participant_id')
         }
         # Send post request
         response = self.client.post(url_for(SAMPLES_LIST_URL),
@@ -59,6 +51,7 @@ class SampleTest(FlaskTestCase):
         for k, v in kwargs.items():
             if k is not 'participant_id':
                 self.assertEqual(sample.get(k), v)
+        self.assertEqual(2, Sample.query.count())
 
     def test_post_missing_req_params(self):
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,7 +34,7 @@ class TestAPI:
         ('/persons', 'GET', 'not found'),
         ('/samples', 'GET', 'success'),
         ('/samples/123', 'GET', 'could not find sample `123`'),
-        ('/samples/123', 'PUT', 'could not find sample `123`'),
+        ('/samples/123', 'PATCH', 'could not find sample `123`'),
         ('/samples/123', 'DELETE', 'could not find sample `123`'),
         ('/diagnoses', 'GET', 'success'),
         ('/diagnoses/123', 'GET', 'could not find diagnosis `123`'),
@@ -79,7 +79,8 @@ class TestAPI:
         ('/participants', 'POST', ['created_at', 'modified_at']),
         ('/participants', 'PATCH', ['created_at', 'modified_at']),
         ('/demographics', 'PATCH', ['created_at', 'modified_at']),
-        ('/diagnoses', 'PATCH', ['created_at', 'modified_at'])
+        ('/diagnoses', 'PATCH', ['created_at', 'modified_at']),
+        ('/samples', 'PATCH', ['created_at', 'modified_at'])
     ])
     def test_read_only(self, client, entities, endpoint, method, fields):
         """ Test that given fields can not be written or modified """
@@ -104,7 +105,8 @@ class TestAPI:
         ('/demographics', 'PATCH', 'blah'),
         ('/diagnoses', 'POST', 'blah'),
         ('/diagnoses', 'PATCH', 'blah'),
-        ('/samples', 'POST', 'blah')
+        ('/samples', 'POST', 'blah'),
+        ('/samples', 'PATCH', 'blah')
     ])
     def test_unknown_field(self, client, entities, endpoint, method, field):
         """ Test that unknown fields are rejected when trying to create  """
@@ -126,7 +128,8 @@ class TestAPI:
 
     @pytest.mark.parametrize('resource,field', [
         ('/participants', 'demographic'),
-        ('/participants', 'diagnoses')
+        ('/participants', 'diagnoses'),
+        ('/participants', 'samples'),
     ])
     def test_relations(self, client, entities, resource, field):
         """ Checks that references to other resources have correct ID """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,9 +45,9 @@ class TestAPI:
         ('/demographics/123', 'PATCH', 'could not find demographic `123`'),
         ('/demographics/123', 'DELETE', 'could not find demographic `123`'),
         ('/participants', 'GET', 'success'),
-        ('/participants/123', 'GET', 'could not find Participant `123`'),
-        ('/participants/123', 'PATCH', 'could not find Participant `123`'),
-        ('/participants/123', 'DELETE', 'could not find Participant `123`')
+        ('/participants/123', 'GET', 'could not find participant `123`'),
+        ('/participants/123', 'PATCH', 'could not find participant `123`'),
+        ('/participants/123', 'DELETE', 'could not find participant `123`')
     ])
     def test_status_messages(self, client, endpoint, method, status_message):
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,8 @@ class TestAPI:
         ('/samples/123', 'GET', 404),
         ('/diagnoses', 'GET', 200),
         ('/diagnoses/123', 'GET', 404),
+        ('/demographics', 'GET', 200),
+        ('/demographics/123', 'GET', 404),
         ('/participants', 'GET', 200),
         ('/persons', 'GET', 404),
         ('/participants/123', 'GET', 404)
@@ -38,6 +40,10 @@ class TestAPI:
         ('/diagnoses/123', 'GET', 'could not find diagnosis `123`'),
         ('/diagnoses/123', 'PUT', 'could not find diagnosis `123`'),
         ('/diagnoses/123', 'DELETE', 'could not find diagnosis `123`'),
+        ('/demographics', 'GET', 'success'),
+        ('/demographics/123', 'GET', 'could not find demographic `123`'),
+        ('/demographics/123', 'PATCH', 'could not find demographic `123`'),
+        ('/demographics/123', 'DELETE', 'could not find demographic `123`'),
         ('/participants', 'GET', 'success'),
         ('/participants/123', 'GET', 'could not find Participant `123`'),
         ('/participants/123', 'PATCH', 'could not find Participant `123`'),
@@ -56,7 +62,8 @@ class TestAPI:
     @pytest.mark.parametrize('endpoint,method', [
         ('/participants', 'GET'),
         ('/samples', 'GET'),
-        ('/diagnoses', 'GET')
+        ('/diagnoses', 'GET'),
+        ('/demographics', 'GET')
     ])
     def test_status_format(self, client, endpoint, method):
         """ Test that the _response field is consistent """
@@ -68,24 +75,32 @@ class TestAPI:
         assert 'code' in body['_status']
         assert type(body['_status']['code']) is int
 
-    @pytest.mark.parametrize('endpoint,field', [
-        ('/participants', 'created_at'),
-        ('/participants', 'modified_at')
+    @pytest.mark.parametrize('endpoint, method, fields', [
+        ('/participants', 'POST', ['created_at', 'modified_at']),
+        ('/participants', 'PATCH', ['created_at', 'modified_at']),
+        ('/demographics', 'PATCH', ['created_at', 'modified_at'])
     ])
-    def test_read_only(self, client, entities, endpoint, field):
+    def test_read_only(self, client, entities, endpoint, method, fields):
         """ Test that given fields can not be written or modified """
         inputs = entities[endpoint]
-        inputs.update({field: 'test'})
-        resp = client.post(endpoint,
-                           data=json.dumps(inputs),
-                           headers={'Content-Type': 'application/json'})
+        method_name = method.lower()
+        [inputs.update({field: 'test'}) for field in fields]
+        call_func = getattr(client, method_name)
+        kwargs = {'data': json.dumps(inputs),
+                  'headers': {'Content-Type': 'application/json'}}
+        if method_name in {'put', 'patch'}:
+            kf_id = entities.get('kf_ids').get(endpoint)
+            endpoint = '{}/{}'.format(endpoint, kf_id)
+        resp = call_func(endpoint, **kwargs)
         body = json.loads(resp.data.decode('utf-8'))
-        assert (field not in body['results']
-                or body['results'][field] != 'test')
+        for field in fields:
+            assert (field not in body['results']
+                    or body['results'][field] != 'test')
 
     @pytest.mark.parametrize('endpoint, method, field', [
         ('/participants', 'POST', 'blah'),
         ('/participants', 'PATCH', 'blah'),
+        ('/demographics', 'PATCH', 'blah'),
         ('/samples', 'POST', 'blah')
     ])
     def test_unknown_field(self, client, entities, endpoint, method, field):
@@ -93,7 +108,7 @@ class TestAPI:
         inputs = entities[endpoint]
         inputs.update({field: 'test'})
         action = 'create'
-        if method.lower() in ['put', 'patch']:
+        if method.lower() in {'put', 'patch'}:
             action = 'update'
             kf_id = entities.get('kf_ids').get(endpoint)
             endpoint = '{}/{}'.format(endpoint, kf_id)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,19 +99,15 @@ class TestAPI:
             assert (field not in body['results']
                     or body['results'][field] != 'test')
 
-    @pytest.mark.parametrize('endpoint, method, field', [
-        ('/participants', 'POST', 'blah'),
-        ('/participants', 'PATCH', 'blah'),
-        ('/demographics', 'PATCH', 'blah'),
-        ('/diagnoses', 'POST', 'blah'),
-        ('/diagnoses', 'PATCH', 'blah'),
-        ('/samples', 'POST', 'blah'),
-        ('/samples', 'PATCH', 'blah')
-    ])
-    def test_unknown_field(self, client, entities, endpoint, method, field):
+    @pytest.mark.parametrize('method', ['POST', 'PATCH'])
+    @pytest.mark.parametrize('endpoint', ['/participants',
+                                          '/demographics',
+                                          '/diagnoses',
+                                          '/samples'])
+    def test_unknown_field(self, client, entities, endpoint, method):
         """ Test that unknown fields are rejected when trying to create  """
         inputs = entities[endpoint]
-        inputs.update({field: 'test'})
+        inputs.update({'blah': 'test'})
         action = 'create'
         if method.lower() in {'put', 'patch'}:
             action = 'update'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,7 @@ class TestAPI:
         ('/samples/123', 'DELETE', 'could not find sample `123`'),
         ('/diagnoses', 'GET', 'success'),
         ('/diagnoses/123', 'GET', 'could not find diagnosis `123`'),
-        ('/diagnoses/123', 'PUT', 'could not find diagnosis `123`'),
+        ('/diagnoses/123', 'PATCH', 'could not find diagnosis `123`'),
         ('/diagnoses/123', 'DELETE', 'could not find diagnosis `123`'),
         ('/demographics', 'GET', 'success'),
         ('/demographics/123', 'GET', 'could not find demographic `123`'),
@@ -78,7 +78,8 @@ class TestAPI:
     @pytest.mark.parametrize('endpoint, method, fields', [
         ('/participants', 'POST', ['created_at', 'modified_at']),
         ('/participants', 'PATCH', ['created_at', 'modified_at']),
-        ('/demographics', 'PATCH', ['created_at', 'modified_at'])
+        ('/demographics', 'PATCH', ['created_at', 'modified_at']),
+        ('/diagnoses', 'PATCH', ['created_at', 'modified_at'])
     ])
     def test_read_only(self, client, entities, endpoint, method, fields):
         """ Test that given fields can not be written or modified """
@@ -101,6 +102,8 @@ class TestAPI:
         ('/participants', 'POST', 'blah'),
         ('/participants', 'PATCH', 'blah'),
         ('/demographics', 'PATCH', 'blah'),
+        ('/diagnoses', 'POST', 'blah'),
+        ('/diagnoses', 'PATCH', 'blah'),
         ('/samples', 'POST', 'blah')
     ])
     def test_unknown_field(self, client, entities, endpoint, method, field):


### PR DESCRIPTION
For participant, demographic, diagnosis, and sample - change the PUT http method in the resource class to PATCH http method. 

- Previous PUT implementation was actually a PATCH implementation. PATCH allows for partial update of resources. PUT replaces the entire resource and will be implemented in the near future. 

For participant, demographic, diagnosis, and sample - change method of retrieval of resource to use SQLAlchemy get() which is optimized for retrieval by primary key.