### PR TITLE
 🔒 Avoid system calls during status request

### DIFF
--- a/dataservice/__init__.py
+++ b/dataservice/__init__.py
@@ -141,6 +141,10 @@ def prefetch_status(app):
                                 ['git', 'rev-parse', '--short', 'HEAD'])
                                 .decode("utf-8").strip())
 
+    app.config['GIT_BRANCH'] = (subprocess.check_output(
+                                ['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+                                .decode("utf-8").strip())
+
     tags = (subprocess.check_output(
             ['git', 'tag', '-l', '--points-at', 'HEAD'])
             .decode('utf-8').split('\n'))

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -118,6 +118,7 @@ class StatusSchema(Schema):
     code = fields.Integer(description='HTTP response code', example=200)
     version = fields.Str(description='API version number', example='1.2.0')
     commit = fields.Str(description='API short commit hash', example='aef3b5a')
+    branch = fields.Str(description='API branch name', example='master')
     tags = fields.List(
             fields.String(description='Any tags associated with the version',
                           example=['rc', 'beta']))

--- a/dataservice/api/status/resources.py
+++ b/dataservice/api/status/resources.py
@@ -1,9 +1,6 @@
-import os
-import subprocess
-
+from flask import current_app
 from flask.views import MethodView
 
-from dataservice.utils import _get_version
 from dataservice.api.common.schemas import StatusSchema
 
 
@@ -26,19 +23,11 @@ class StatusAPI(MethodView):
                 schema:
                     $ref: '#/definitions/Status'
         """
-        commit = (subprocess.check_output(
-                  ['git', 'rev-parse', '--short', 'HEAD'])
-                  .decode("utf-8").strip())
-
-        tags = (subprocess.check_output(
-                ['git', 'tag', '-l', '--points-at', 'HEAD'])
-                .decode('utf-8').split('\n'))
-        tags = [] if tags[0] == '' else tags
         resp = {
                 'message': 'Welcome to the Kids First Dataservice API',
                 'code': 200,
-                'version': _get_version(),
-                'commit': commit,
-                'tags': tags
+                'version': current_app.config['PKG_VERSION'],
+                'commit': current_app.config['GIT_COMMIT'],
+                'tags': current_app.config['GIT_TAGS']
         }
         return StatusSchema().jsonify(resp)

--- a/dataservice/api/status/resources.py
+++ b/dataservice/api/status/resources.py
@@ -28,6 +28,7 @@ class StatusAPI(MethodView):
                 'code': 200,
                 'version': current_app.config['PKG_VERSION'],
                 'commit': current_app.config['GIT_COMMIT'],
+                'branch': current_app.config['GIT_BRANCH'],
                 'tags': current_app.config['GIT_TAGS']
         }
         return StatusSchema().jsonify(resp)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -123,6 +123,7 @@ class TestAPI:
         status = status['_status']
         assert 'commit' in status
         assert len(status['commit']) == 7
+        assert 'branch' in status
         assert 'version' in status
         assert status['version'].count('.') == 2
         assert 'tags' in status


### PR DESCRIPTION
Fixes potential security vulnerability and performance issue by pre-calculating details about the git status and package version on app creation.
Also adds a 'branch' field to the status.

Also increases response throughput considerably:
run with: `gunicorn -b :5000 --access-logfile - manage:app --threads 8 --workers 2`
test with: `wrk -t1 -c12 -d60s 'http://localhost:5000/status'`

System call every request:
```
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   292.03ms  354.49ms   1.66s    85.46%
    Req/Sec    65.54     15.77   116.00     70.61%
  3928 requests in 1.00m, 1.22MB read
  Socket errors: connect 0, read 0, write 0, timeout 2
Requests/sec:     65.43
Transfer/sec:     20.83KB
```

Pre-cached response:
```
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    13.48ms    7.54ms 125.42ms   81.26%
    Req/Sec     0.93k    68.38     1.11k    64.83%
  55605 requests in 1.00m, 17.29MB read
Requests/sec:    925.68
Transfer/sec:    294.70KB
```

Fixes #171 