### PR TITLE
♻️ Fix self links

### DIFF
--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -56,10 +56,10 @@ class BaseSchema(ma.ModelSchema):
 
             # If an 'after' param could not be parsed, don't include the param
             after = None if p.after.timestamp() == 0 else p.curr_num
-            _links['self'] = url_for(self.Meta.resource_url,
+            _links['self'] = url_for(self.Meta.collection_url,
                                      after=after)
             if p.has_next:
-                _links['next'] = url_for(self.Meta.resource_url,
+                _links['next'] = url_for(self.Meta.collection_url,
                                          after=p.next_num)
             resp['total'] = int(p.total)
             resp['limit'] = int(p.limit)

--- a/dataservice/api/demographic/schemas.py
+++ b/dataservice/api/demographic/schemas.py
@@ -14,11 +14,12 @@ class DemographicSchema(BaseSchema):
                                load_only=True)
 
     class Meta(BaseSchema.Meta):
-        resource_url = 'api.demographics_list'
+        resource_url = 'api.demographics'
+        collection_url = 'api.demographics_list'
         model = Demographic
 
     _links = ma.Hyperlinks({
-        'self': ma.URLFor('api.demographics', kf_id='<kf_id>'),
-        'collection': ma.URLFor('api.demographics_list'),
+        'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
+        'collection': ma.URLFor(Meta.collection_url),
         'participant': ma.URLFor('api.participants', kf_id='<participant_id>')
     })

--- a/dataservice/api/diagnosis/schemas.py
+++ b/dataservice/api/diagnosis/schemas.py
@@ -20,10 +20,11 @@ class DiagnosisSchema(BaseSchema):
 
     class Meta(BaseSchema.Meta):
         model = Diagnosis
-        resource_url = 'api.diagnoses_list'
+        resource_url = 'api.diagnoses'
+        collection_url = 'api.diagnoses_list'
 
     _links = ma.Hyperlinks({
-        'self': ma.URLFor('api.diagnoses', kf_id='<kf_id>'),
-        'collection': ma.URLFor('api.diagnoses_list'),
+        'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
+        'collection': ma.URLFor(Meta.collection_url),
         'participant': ma.URLFor('api.participants', kf_id='<participant_id>')
     })

--- a/dataservice/api/participant/schemas.py
+++ b/dataservice/api/participant/schemas.py
@@ -16,9 +16,10 @@ class ParticipantSchema(BaseSchema):
 
     class Meta(BaseSchema.Meta):
         model = Participant
-        resource_url = 'api.participants_list'
+        resource_url = 'api.participants'
+        collection_url = 'api.participants_list'
 
     _links = ma.Hyperlinks({
-        'self': ma.URLFor('api.participants', kf_id='<kf_id>'),
-        'collection': ma.URLFor('api.participants_list')
+        'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
+        'collection': ma.URLFor(Meta.collection_url)
     })

--- a/dataservice/api/participant/schemas.py
+++ b/dataservice/api/participant/schemas.py
@@ -19,5 +19,6 @@ class ParticipantSchema(BaseSchema):
         resource_url = 'api.participants_list'
 
     _links = ma.Hyperlinks({
-        'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>')
+        'self': ma.URLFor('api.participants', kf_id='<kf_id>'),
+        'collection': ma.URLFor('api.participants_list')
     })

--- a/dataservice/api/sample/schemas.py
+++ b/dataservice/api/sample/schemas.py
@@ -19,10 +19,11 @@ class SampleSchema(BaseSchema):
 
     class Meta(BaseSchema.Meta):
         model = Sample
-        resource_url = 'api.samples_list'
+        resource_url = 'api.samples'
+        collection_url = 'api.samples_list'
 
     _links = ma.Hyperlinks({
-        'self': ma.URLFor('api.samples', kf_id='<kf_id>'),
-        'collection': ma.URLFor('api.samples_list'),
+        'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
+        'collection': ma.URLFor(Meta.collection_url),
         'participant': ma.URLFor('api.participants', kf_id='<participant_id>')
     })

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -134,3 +134,27 @@ class TestPagination:
         response = client.get(response['_links']['self'])
         response = json.loads(response.data.decode('utf-8'))
         assert results == response['results']
+
+    @pytest.mark.parametrize('endpoint', [
+        ('/participants'),
+        ('/demographics'),
+        ('/samples'),
+        ('/diagnoses'),
+    ])
+    def test_individual_links(self, client, participants, endpoint):
+        """ Test that each individual result has properly formatted _links """
+        response = client.get(endpoint)
+        response = json.loads(response.data.decode('utf-8'))
+        results = response['results']
+
+        for result in results:
+            assert '_links' in result
+            self_link = result['_links']
+            response = client.get(result['_links']['self'])
+            assert response.status_code  == 200
+            response = json.loads(response.data.decode('utf-8'))
+            assert response['_status']['code'] == 200
+            # Should only return the single entity
+            assert isinstance(response['results'], dict)
+            assert result['kf_id'] == response['results']['kf_id']
+            assert 'collection' in result['_links']


### PR DESCRIPTION
Added `resource_url` and `collection_url` for each schema.

We may be able to get rid of the manual `_link` definitions by putt logic into the common schema or by extending marshmallow-sqlalchemy.

Fixes #172, resolves #182 