### PR TITLE
⚡️ Only load relation's kf_id

### DIFF
--- a/dataservice/api/aliquot/resources.py
+++ b/dataservice/api/aliquot/resources.py
@@ -1,4 +1,5 @@
 from flask import abort, request
+from sqlalchemy.orm import joinedload
 from marshmallow import ValidationError
 
 from dataservice.extensions import db
@@ -29,7 +30,11 @@ class AliquotListAPI(CRUDView):
             resource:
               Aliquot
         """
-        q = Aliquot.query
+        q = (Aliquot.query
+                    .options(
+                        joinedload('sequencing_experiments')
+                        .load_only('kf_id')
+                     ))
 
         return (AliquotSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/sample/resources.py
+++ b/dataservice/api/sample/resources.py
@@ -1,9 +1,10 @@
 from flask import abort, request
+from sqlalchemy.orm import joinedload
 from marshmallow import ValidationError
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
-from dataservice.api.sample.models import Sample
+from dataservice.api.sample.models import Sample, Aliquot
 from dataservice.api.sample.schemas import SampleSchema
 from dataservice.api.common.views import CRUDView
 
@@ -29,7 +30,11 @@ class SampleListAPI(CRUDView):
             resource:
               Sample
         """
-        q = Sample.query
+        q = (Sample.query
+                   .options(
+                       joinedload('aliquots')
+                       .load_only('kf_id')
+                    ))
 
         return (SampleSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))


### PR DESCRIPTION
Increases aliquot and sample paginated endpoints by only loading the `kf_id` of related entities.
Also decreases of sequential page scanning by roughly the same amount.

Baseline:
```
wrk -t1 -c12 -d60s 'http://localhost:5000/samples?limit=100'
Running 1m test @ http://localhost:5000/samples?limit=100
  1 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.10s   556.88ms   1.84s    66.67%
    Req/Sec     3.09      0.49     5.00     85.15%
  202 requests in 1.00m, 12.68MB read
  Socket errors: connect 0, read 0, write 0, timeout 196
Requests/sec:      3.37
Transfer/sec:    216.35KB
```

With `load_only` kf_id on relations:
```
wrk -t1 -c12 -d60s 'http://localhost:5000/samples?limit=100'
Running 1m test @ http://localhost:5000/samples?limit=100
  1 threads and 12 connections
Bn  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   877.35ms   91.07ms   1.18s    87.10%
    Req/Sec    13.28      5.01    20.00     60.76%
  814 requests in 1.00m, 51.10MB read
Requests/sec:     13.55
Transfer/sec:      0.85MB
```