### PR TITLE
✨ Filter Resources by Study 

### DIFF
--- a/dataservice/api/README.md
+++ b/dataservice/api/README.md
@@ -83,6 +83,14 @@ to paginate. Specific dates may also be used. For example:
 ```
 Will list all participants created after December 1st, 2017.
 
+Most pagninated resource endpoints also accept the `study_id` query parameter so that
+results may be filtered by study. For example:
+
+```
+"/participants?after=01-12-2017&study_id=SD_7AWKP3JN"
+```
+
+Will return participants created after December 1st, 2017 and which belong to the study identified by the Kids First ID: SD_7AWKP3JN.
 
 An example of the envelope wrapping a paginated response:
 ```json

--- a/dataservice/api/biospecimen/resources.py
+++ b/dataservice/api/biospecimen/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load, load_only
+from sqlalchemy.orm import joinedload
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,14 +30,15 @@ class BiospecimenListAPI(CRUDView):
             resource:
               Biospecimen
         """
-        q = Biospecimen.query.options(load_only('kf_id'))
+        q = Biospecimen.query
 
         # Filter by study
         from dataservice.api.participant.models import Participant
         study_id = request.args.get('study_id')
         if study_id:
-            q = (q.join(Participant.biospecimens)
-                 .options(Load(Participant).load_only('kf_id', 'study_id'))
+            q = (q.options(joinedload(Biospecimen.genomic_files)
+                           .load_only('kf_id'))
+                 .join(Participant.biospecimens)
                  .filter(Participant.study_id == study_id))
 
         return (BiospecimenSchema(many=True)

--- a/dataservice/api/biospecimen/resources.py
+++ b/dataservice/api/biospecimen/resources.py
@@ -1,5 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
+from sqlalchemy.orm import Load
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,6 +31,14 @@ class BiospecimenListAPI(CRUDView):
               Biospecimen
         """
         q = Biospecimen.query
+
+        # Filter by study
+        from dataservice.api.participant.models import Participant
+        study_id = request.args.get('study_id')
+        if study_id:
+            q = (q.join(Participant.biospecimens)
+                 .options(Load(Participant).load_only('kf_id', 'study_id'))
+                 .filter(Participant.study_id == study_id))
 
         return (BiospecimenSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/biospecimen/resources.py
+++ b/dataservice/api/biospecimen/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load
+from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,7 +30,7 @@ class BiospecimenListAPI(CRUDView):
             resource:
               Biospecimen
         """
-        q = Biospecimen.query
+        q = Biospecimen.query.options(load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/common/pagination.py
+++ b/dataservice/api/common/pagination.py
@@ -29,7 +29,9 @@ def paginated(f):
         if after is None:
             after = datetime.fromtimestamp(0)
 
-        return f(*args, **kwargs, after=after, limit=limit)
+        return f(*args, **kwargs,
+                 after=after,
+                 limit=limit)
 
     return paginated_wrapper
 
@@ -67,7 +69,7 @@ class Pagination(object):
         so that the current timestamp will be included in the range
         """
         if len(self.items) > 0:
-            return self._to_timestamp(self.items[0].created_at) - 1/100000
+            return self._to_timestamp(self.items[0].created_at) - 1 / 100000
         return self._to_timestamp(datetime.utcnow())
 
     @property

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -6,7 +6,7 @@ from marshmallow import (
     validates_schema,
     ValidationError
 )
-from flask import url_for
+from flask import url_for, request
 from dataservice.api.common.pagination import Pagination
 from flask_marshmallow import Schema
 
@@ -57,7 +57,8 @@ class BaseSchema(ma.ModelSchema):
             # If an 'after' param could not be parsed, don't include the param
             after = None if p.after.timestamp() == 0 else p.curr_num
             _links['self'] = url_for(self.Meta.collection_url,
-                                     after=after)
+                                     after=after,
+                                     study_id=request.args.get('study_id'))
             if p.has_next:
                 _links['next'] = url_for(self.Meta.collection_url,
                                          after=p.next_num)

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -61,7 +61,8 @@ class BaseSchema(ma.ModelSchema):
                                      study_id=request.args.get('study_id'))
             if p.has_next:
                 _links['next'] = url_for(self.Meta.collection_url,
-                                         after=p.next_num)
+                                         after=p.next_num,
+                                         study_id=request.args.get('study_id'))
             resp['total'] = int(p.total)
             resp['limit'] = int(p.limit)
         else:

--- a/dataservice/api/diagnosis/resources.py
+++ b/dataservice/api/diagnosis/resources.py
@@ -1,6 +1,5 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,14 +29,13 @@ class DiagnosisListAPI(CRUDView):
             resource:
               Diagnosis
         """
-        q = Diagnosis.query.options(load_only('kf_id'))
+        q = Diagnosis.query
 
         # Filter by study
         from dataservice.api.participant.models import Participant
         study_id = request.args.get('study_id')
         if study_id:
             q = (q.join(Participant.diagnoses)
-                 .options(Load(Participant).load_only('kf_id', 'study_id'))
                  .filter(Participant.study_id == study_id))
 
         return (DiagnosisSchema(many=True)

--- a/dataservice/api/diagnosis/resources.py
+++ b/dataservice/api/diagnosis/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load
+from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,7 +30,7 @@ class DiagnosisListAPI(CRUDView):
             resource:
               Diagnosis
         """
-        q = Diagnosis.query
+        q = Diagnosis.query.options(load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/diagnosis/resources.py
+++ b/dataservice/api/diagnosis/resources.py
@@ -1,5 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
+from sqlalchemy.orm import Load
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,6 +31,14 @@ class DiagnosisListAPI(CRUDView):
               Diagnosis
         """
         q = Diagnosis.query
+
+        # Filter by study
+        from dataservice.api.participant.models import Participant
+        study_id = request.args.get('study_id')
+        if study_id:
+            q = (q.join(Participant.diagnoses)
+                 .options(Load(Participant).load_only('kf_id', 'study_id'))
+                 .filter(Participant.study_id == study_id))
 
         return (DiagnosisSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/family/resources.py
+++ b/dataservice/api/family/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load
+from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -29,7 +29,7 @@ class FamilyListAPI(CRUDView):
             resource:
               Family
         """
-        q = Family.query
+        q = Family.query.options(load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/family/resources.py
+++ b/dataservice/api/family/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load, load_only
+from sqlalchemy.orm import joinedload
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -29,14 +29,14 @@ class FamilyListAPI(CRUDView):
             resource:
               Family
         """
-        q = Family.query.options(load_only('kf_id'))
+        q = Family.query
 
         # Filter by study
         from dataservice.api.participant.models import Participant
         study_id = request.args.get('study_id')
         if study_id:
-            q = (q.join(Family.participants)
-                 .options(Load(Participant).load_only('kf_id', 'study_id'))
+            q = (q.options(joinedload(Family.participants).load_only('kf_id'))
+                 .join(Family.participants)
                  .filter(Participant.study_id == study_id)
                  .distinct(Family.kf_id)
                  .order_by(Family.kf_id))

--- a/dataservice/api/family/resources.py
+++ b/dataservice/api/family/resources.py
@@ -38,8 +38,7 @@ class FamilyListAPI(CRUDView):
             q = (q.options(joinedload(Family.participants).load_only('kf_id'))
                  .join(Family.participants)
                  .filter(Participant.study_id == study_id)
-                 .distinct(Family.kf_id)
-                 .order_by(Family.kf_id))
+                 .group_by(Family.kf_id))
 
         return (FamilySchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/family_relationship/resources.py
+++ b/dataservice/api/family_relationship/resources.py
@@ -1,6 +1,5 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -32,14 +31,13 @@ class FamilyRelationshipListAPI(CRUDView):
             resource:
               FamilyRelationship
         """
-        q = FamilyRelationship.query.options(load_only('kf_id'))
+        q = FamilyRelationship.query
 
         # Filter by study
         from dataservice.api.participant.models import Participant
         study_id = request.args.get('study_id')
         if study_id:
             q = (q.join(FamilyRelationship.participant)
-                 .options(Load(Participant).load_only('kf_id', 'study_id'))
                  .filter(Participant.study_id == study_id))
 
         return (FamilyRelationshipSchema(many=True)

--- a/dataservice/api/family_relationship/resources.py
+++ b/dataservice/api/family_relationship/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load
+from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -32,7 +32,7 @@ class FamilyRelationshipListAPI(CRUDView):
             resource:
               FamilyRelationship
         """
-        q = FamilyRelationship.query
+        q = FamilyRelationship.query.options(load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/family_relationship/resources.py
+++ b/dataservice/api/family_relationship/resources.py
@@ -1,5 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
+from sqlalchemy.orm import Load
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -32,6 +33,14 @@ class FamilyRelationshipListAPI(CRUDView):
               FamilyRelationship
         """
         q = FamilyRelationship.query
+
+        # Filter by study
+        from dataservice.api.participant.models import Participant
+        study_id = request.args.get('study_id')
+        if study_id:
+            q = (q.join(FamilyRelationship.participant)
+                 .options(Load(Participant).load_only('kf_id', 'study_id'))
+                 .filter(Participant.study_id == study_id))
 
         return (FamilyRelationshipSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/genomic_file/resources.py
+++ b/dataservice/api/genomic_file/resources.py
@@ -1,6 +1,5 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -33,7 +32,7 @@ class GenomicFileListAPI(CRUDView):
               GenomicFile
         """
         # Get a page of the data from the model first
-        q = GenomicFile.query.options(load_only('kf_id'))
+        q = GenomicFile.query
 
         # Filter by study
         from dataservice.api.participant.models import Participant
@@ -42,7 +41,6 @@ class GenomicFileListAPI(CRUDView):
         if study_id:
             q = (q.join(GenomicFile.biospecimen)
                  .join(Biospecimen.participant)
-                 .options(Load(Participant).load_only("kf_id", "study_id"))
                  .filter(Participant.study_id == study_id))
 
         pager = Pagination(q, after, limit)

--- a/dataservice/api/genomic_file/resources.py
+++ b/dataservice/api/genomic_file/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load
+from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -33,7 +33,7 @@ class GenomicFileListAPI(CRUDView):
               GenomicFile
         """
         # Get a page of the data from the model first
-        q = GenomicFile.query
+        q = GenomicFile.query.options(load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/genomic_file/resources.py
+++ b/dataservice/api/genomic_file/resources.py
@@ -1,5 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
+from sqlalchemy.orm import Load
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -33,7 +34,16 @@ class GenomicFileListAPI(CRUDView):
         """
         # Get a page of the data from the model first
         q = GenomicFile.query
-        refresh = True
+
+        # Filter by study
+        from dataservice.api.participant.models import Participant
+        from dataservice.api.biospecimen.models import Biospecimen
+        study_id = request.args.get('study_id')
+        if study_id:
+            q = (q.join(GenomicFile.biospecimen)
+                 .join(Biospecimen.participant)
+                 .options(Load(Participant).load_only("kf_id", "study_id"))
+                 .filter(Participant.study_id == study_id))
 
         pager = Pagination(q, after, limit)
         keep = []

--- a/dataservice/api/investigator/resources.py
+++ b/dataservice/api/investigator/resources.py
@@ -1,5 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
+from sqlalchemy.orm import Load
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -29,6 +30,14 @@ class InvestigatorListAPI(CRUDView):
               Investigator
         """
         q = Investigator.query
+
+        # Filter by study
+        from dataservice.api.study.models import Study
+        study_id = request.args.get('study_id')
+        if study_id:
+            q = (q.join(Investigator.studies)
+                 .options(Load(Study).load_only('kf_id'))
+                 .filter(Study.kf_id == study_id))
 
         return (InvestigatorSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/investigator/resources.py
+++ b/dataservice/api/investigator/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load, load_only
+from sqlalchemy.orm import joinedload
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -29,14 +29,14 @@ class InvestigatorListAPI(CRUDView):
             resource:
               Investigator
         """
-        q = Investigator.query.options(load_only('kf_id'))
+        q = Investigator.query
 
         # Filter by study
         from dataservice.api.study.models import Study
         study_id = request.args.get('study_id')
         if study_id:
-            q = (q.join(Investigator.studies)
-                 .options(Load(Study).load_only('kf_id'))
+            q = (q.options(joinedload(Investigator.studies).load_only('kf_id'))
+                 .join(Investigator.studies)
                  .filter(Study.kf_id == study_id))
 
         return (InvestigatorSchema(many=True)

--- a/dataservice/api/investigator/resources.py
+++ b/dataservice/api/investigator/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load
+from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -29,7 +29,7 @@ class InvestigatorListAPI(CRUDView):
             resource:
               Investigator
         """
-        q = Investigator.query
+        q = Investigator.query.options(load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.study.models import Study

--- a/dataservice/api/outcome/resources.py
+++ b/dataservice/api/outcome/resources.py
@@ -30,14 +30,13 @@ class OutcomeListAPI(CRUDView):
             resource:
               Outcome
         """
-        q = Outcome.query.options(load_only('kf_id'))
+        q = Outcome.query
 
         # Filter by study
         from dataservice.api.participant.models import Participant
         study_id = request.args.get('study_id')
         if study_id:
             q = (q.join(Participant.outcomes)
-                 .options(Load(Participant).load_only('kf_id', 'study_id'))
                  .filter(Participant.study_id == study_id))
 
         return (OutcomeSchema(many=True)

--- a/dataservice/api/outcome/resources.py
+++ b/dataservice/api/outcome/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load
+from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,7 +30,7 @@ class OutcomeListAPI(CRUDView):
             resource:
               Outcome
         """
-        q = Outcome.query
+        q = Outcome.query.options(load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -30,10 +30,19 @@ class ParticipantListAPI(CRUDView):
               Participant
         """
         q = (Participant.query
-                        .options(joinedload(Participant.diagnoses))
-                        .options(joinedload(Participant.biospecimens))
-                        .options(joinedload(Participant.phenotypes))
-                        .options(joinedload(Participant.outcomes)))
+                        .options(joinedload(Participant.diagnoses)
+                                 .load_only('kf_id'))
+                        .options(joinedload(Participant.biospecimens)
+                                 .load_only('kf_id'))
+                        .options(joinedload(Participant.phenotypes)
+                                 .load_only('kf_id'))
+                        .options(joinedload(Participant.outcomes)
+                                 .load_only('kf_id')))
+
+        # Filter by study
+        study_id = request.args.get('study_id')
+        if study_id:
+            q = q.filter_by(study_id=study_id)
 
         return (ParticipantSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/phenotype/resources.py
+++ b/dataservice/api/phenotype/resources.py
@@ -1,5 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
+from sqlalchemy.orm import Load
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,6 +31,14 @@ class PhenotypeListAPI(CRUDView):
               Phenotype
         """
         q = Phenotype.query
+
+        # Filter by study
+        from dataservice.api.participant.models import Participant
+        study_id = request.args.get('study_id')
+        if study_id:
+            q = (q.join(Participant.phenotypes)
+                 .options(Load(Participant).load_only('kf_id', 'study_id'))
+                 .filter(Participant.study_id == study_id))
 
         return (PhenotypeSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/phenotype/resources.py
+++ b/dataservice/api/phenotype/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load
+from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,7 +30,7 @@ class PhenotypeListAPI(CRUDView):
             resource:
               Phenotype
         """
-        q = Phenotype.query
+        q = Phenotype.query.options(load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/phenotype/resources.py
+++ b/dataservice/api/phenotype/resources.py
@@ -1,6 +1,5 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -30,14 +29,13 @@ class PhenotypeListAPI(CRUDView):
             resource:
               Phenotype
         """
-        q = Phenotype.query.options(load_only('kf_id'))
+        q = Phenotype.query
 
         # Filter by study
         from dataservice.api.participant.models import Participant
         study_id = request.args.get('study_id')
         if study_id:
             q = (q.join(Participant.phenotypes)
-                 .options(Load(Participant).load_only('kf_id', 'study_id'))
                  .filter(Participant.study_id == study_id))
 
         return (PhenotypeSchema(many=True)

--- a/dataservice/api/sequencing_experiment/resources.py
+++ b/dataservice/api/sequencing_experiment/resources.py
@@ -1,6 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import Load
+from sqlalchemy.orm import Load, load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -32,7 +32,7 @@ class SequencingExperimentListAPI(CRUDView):
             resource:
               SequencingExperiment
         """
-        q = SequencingExperiment.query
+        q = SequencingExperiment.query.options(load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/sequencing_experiment/resources.py
+++ b/dataservice/api/sequencing_experiment/resources.py
@@ -1,5 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
+from sqlalchemy.orm import Load
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -32,6 +33,19 @@ class SequencingExperimentListAPI(CRUDView):
               SequencingExperiment
         """
         q = SequencingExperiment.query
+
+        # Filter by study
+        from dataservice.api.participant.models import Participant
+        from dataservice.api.biospecimen.models import Biospecimen
+        from dataservice.api.genomic_file.models import GenomicFile
+
+        study_id = request.args.get('study_id')
+        if study_id:
+            q = (q.join(SequencingExperiment.genomic_files)
+                 .join(GenomicFile.biospecimen)
+                 .join(Biospecimen.participant)
+                 .options(Load(Participant).load_only("kf_id", "study_id"))
+                 .filter(Participant.study_id == study_id))
 
         return (SequencingExperimentSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/study_file/resources.py
+++ b/dataservice/api/study_file/resources.py
@@ -1,5 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
+from sqlalchemy.orm import load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -28,12 +29,12 @@ class StudyFileListAPI(CRUDView):
             resource:
               StudyFile
         """
-        q = StudyFile.query
+        q = StudyFile.query.options(load_only('kf_id'))
 
         # Filter by study
         study_id = request.args.get('study_id')
         if study_id:
-            q = q.filter_by(study_id=study_id)
+            q = (q.filter_by(study_id=study_id))
 
         return (StudyFileSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/study_file/resources.py
+++ b/dataservice/api/study_file/resources.py
@@ -1,6 +1,5 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import load_only
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -29,7 +28,7 @@ class StudyFileListAPI(CRUDView):
             resource:
               StudyFile
         """
-        q = StudyFile.query.options(load_only('kf_id'))
+        q = StudyFile.query
 
         # Filter by study
         study_id = request.args.get('study_id')

--- a/dataservice/api/study_file/resources.py
+++ b/dataservice/api/study_file/resources.py
@@ -30,6 +30,11 @@ class StudyFileListAPI(CRUDView):
         """
         q = StudyFile.query
 
+        # Filter by study
+        study_id = request.args.get('study_id')
+        if study_id:
+            q = q.filter_by(study_id=study_id)
+
         return (StudyFileSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -41,6 +41,7 @@ class TestPagination:
         # Add a bunch of investigators
         for _ in range(102):
             inv = Investigator(name='test')
+            inv.studies.extend([s0, s1])
             db.session.add(inv)
         db.session.commit()
 
@@ -97,6 +98,8 @@ class TestPagination:
         ('/outcomes', 50),
         ('/phenotypes', 50),
         ('/families', 1),
+        ('/family-relationships', 50),
+        ('/investigators', 1),
     ])
     def test_study_filter(self, client, participants,
                           endpoint, expected_total):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -109,6 +109,7 @@ class TestPagination:
         ('/study-files', 101),
         ('/investigators', 1),
         ('/biospecimens', 50),
+        ('/sequencing-experiments', 50),
         ('/diagnoses', 50),
         ('/outcomes', 50),
         ('/phenotypes', 50),

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -11,6 +11,8 @@ from dataservice.api.outcome.models import Outcome
 from dataservice.api.phenotype.models import Phenotype
 from dataservice.api.diagnosis.models import Diagnosis
 from dataservice.api.biospecimen.models import Biospecimen
+from dataservice.api.genomic_file.models import GenomicFile
+from dataservice.api.sequencing_experiment.models import SequencingExperiment
 from dataservice.api.family_relationship.models import FamilyRelationship
 from dataservice.utils import iterate_pairwise
 from dataservice.api.study_file.models import StudyFile
@@ -69,6 +71,17 @@ class TestPagination:
 
             p = Participant(**data, study_id=s.kf_id, family_id=f.kf_id)
             samp = Biospecimen(analyte_type='an analyte')
+            se_kwargs = {
+                'external_id': 'se1',
+                'experiment_strategy': 'WGS',
+                'center': 'Baylor',
+                'is_paired_end': True,
+                'platform': 'Illumina'
+            }
+            seq_exp = SequencingExperiment(**se_kwargs)
+            gf = GenomicFile()
+            gf.biospecimen = samp
+            gf.sequencing_experiment = seq_exp
             p.biospecimens = [samp]
             diag = Diagnosis()
             p.diagnoses = [diag]
@@ -94,12 +107,13 @@ class TestPagination:
     @pytest.mark.parametrize('endpoint, expected_total', [
         ('/participants', 50),
         ('/study-files', 101),
+        ('/investigators', 1),
+        ('/biospecimens', 50),
         ('/diagnoses', 50),
         ('/outcomes', 50),
         ('/phenotypes', 50),
         ('/families', 1),
         ('/family-relationships', 50),
-        ('/investigators', 1),
     ])
     def test_study_filter(self, client, participants,
                           endpoint, expected_total):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -92,26 +92,30 @@ class TestPagination:
         ('/family-relationships', 101),
         ('/study-files', 101)
     ])
-    def test_filter_study_related_entities(self, client, participants,
-                                           endpoint):
-        """ Test pagination of resource """
+    def test_study_filter_first_order_entities(self, client, participants,
+                                               endpoint):
+        """
+        Test pagination of resources with a study filter
+
+        These resources are directly related to the study by foreign key
+        """
         rel = endpoint.strip('/').replace('-', '_')
         s = Study.query.first()
-        n_pts = len(getattr(s, rel))
+        n_entities = len(getattr(s, rel))
         endpoint = '{}?study_id={}'.format(endpoint, s.kf_id)
         resp = client.get(endpoint)
         resp = json.loads(resp.data.decode('utf-8'))
 
-        assert len(resp['results']) == min(n_pts, 10)
+        assert len(resp['results']) == min(n_entities, 10)
         assert resp['limit'] == 10
-        assert resp['total'] == n_pts
+        assert resp['total'] == n_entities
 
         ids_seen = []
         # Iterate through via the `next` link
         while 'next' in resp['_links']:
             # Check formatting of next link
             assert float(resp['_links']['next'].split('=')[-1])
-            # Check that all participant belong to study
+            # Check that all results have correct study link
             for r in resp['results']:
                 study_id = r['_links']['study'].split('/')[-1]
                 assert study_id == s.kf_id

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -159,6 +159,36 @@ class TestPagination:
 
         assert len(ids_seen) == resp['total']
 
+    @pytest.mark.parametrize('study_id', ['blah', 'ST_00000000', 50])
+    @pytest.mark.parametrize('endpoint', [
+        ('/participants'),
+        ('/study-files'),
+        ('/investigators'),
+        ('/biospecimens'),
+        ('/sequencing-experiments'),
+        ('/diagnoses'),
+        ('/outcomes'),
+        ('/phenotypes'),
+        ('/families'),
+        ('/family-relationships'),
+        ('/genomic-files')
+    ])
+    def test_non_exist_study_filter(self, client, participants,
+                                    endpoint, study_id):
+        """
+        Test pagination of resources with a study filter that doesn't exist or
+        is invalid
+
+        Should return no results
+        """
+        endpoint = '{}?study_id={}'.format(endpoint, study_id)
+        resp = client.get(endpoint)
+        resp = json.loads(resp.data.decode('utf-8'))
+
+        assert len(resp['results']) == 0
+        assert resp['limit'] == 10
+        assert resp['total'] == 0
+
     @pytest.mark.parametrize('endpoint, expected_total', [
         ('/studies', 101),
         ('/investigators', 102),


### PR DESCRIPTION
Not a full implementation of resource query parameters/filters. Should look at using marshmallow schemas with [webargs](https://webargs.readthedocs.io/en/latest/advanced.html#advanced) for more complete implementation of query filters. Simple implementation for one query parameter (study_id):
- /\<resource name\>?study_id=\<study kids first id\>. 

- [x] Filter participants by study_id 
- [x] Filter study files by study_id 
- [x] Filter diagnoses by study_id 
- [x] Filter phenotypes by study_id 
- [x] Filter outcomes by study_id 
- [x] Filter family_relationships by study_id 
- [x] Filter familes by study_id 
- [x] Filter investigators by study_id 
- [x] Filter sequencing_experiment by study_id 

Implement after #145 and #228 merge
- [x] Filter genomic files by study_id
- [x] Filter biospecimens by study_id 