### PR TITLE
⚡️Optimize loading of children in default pagination

### DIFF
--- a/dataservice/api/biospecimen/resources.py
+++ b/dataservice/api/biospecimen/resources.py
@@ -30,15 +30,14 @@ class BiospecimenListAPI(CRUDView):
             resource:
               Biospecimen
         """
-        q = Biospecimen.query
+        q = Biospecimen.query.options(joinedload(Biospecimen.genomic_files)
+                                      .load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant
         study_id = request.args.get('study_id')
         if study_id:
-            q = (q.options(joinedload(Biospecimen.genomic_files)
-                           .load_only('kf_id'))
-                 .join(Participant.biospecimens)
+            q = (q.join(Participant.biospecimens)
                  .filter(Participant.study_id == study_id))
 
         return (BiospecimenSchema(many=True)

--- a/dataservice/api/family/resources.py
+++ b/dataservice/api/family/resources.py
@@ -29,14 +29,14 @@ class FamilyListAPI(CRUDView):
             resource:
               Family
         """
-        q = Family.query
+        q = Family.query.options(joinedload(Family.participants)
+                                 .load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant
         study_id = request.args.get('study_id')
         if study_id:
-            q = (q.options(joinedload(Family.participants).load_only('kf_id'))
-                 .join(Family.participants)
+            q = (q.join(Family.participants)
                  .filter(Participant.study_id == study_id)
                  .group_by(Family.kf_id))
 

--- a/dataservice/api/investigator/resources.py
+++ b/dataservice/api/investigator/resources.py
@@ -29,14 +29,15 @@ class InvestigatorListAPI(CRUDView):
             resource:
               Investigator
         """
-        q = Investigator.query
+        q = Investigator.query.options(
+            joinedload(Investigator.studies)
+            .load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.study.models import Study
         study_id = request.args.get('study_id')
         if study_id:
-            q = (q.options(joinedload(Investigator.studies).load_only('kf_id'))
-                 .join(Investigator.studies)
+            q = (q.join(Investigator.studies)
                  .filter(Study.kf_id == study_id))
 
         return (InvestigatorSchema(many=True)

--- a/dataservice/api/sequencing_experiment/resources.py
+++ b/dataservice/api/sequencing_experiment/resources.py
@@ -32,7 +32,9 @@ class SequencingExperimentListAPI(CRUDView):
             resource:
               SequencingExperiment
         """
-        q = SequencingExperiment.query
+        q = SequencingExperiment.query.options(
+            joinedload(SequencingExperiment.genomic_files)
+            .load_only('kf_id'))
 
         # Filter by study
         from dataservice.api.participant.models import Participant
@@ -41,9 +43,7 @@ class SequencingExperimentListAPI(CRUDView):
 
         study_id = request.args.get('study_id')
         if study_id:
-            q = (q.options(joinedload(SequencingExperiment.genomic_files)
-                           .load_only('kf_id'))
-                 .join(SequencingExperiment.genomic_files)
+            q = (q.join(SequencingExperiment.genomic_files)
                  .join(GenomicFile.biospecimen)
                  .join(Biospecimen.participant)
                  .filter(Participant.study_id == study_id))

--- a/dataservice/api/study/resources.py
+++ b/dataservice/api/study/resources.py
@@ -1,5 +1,6 @@
 from flask import abort, request
 from marshmallow import ValidationError
+from sqlalchemy.orm import joinedload
 
 from dataservice.extensions import db
 from dataservice.api.common.pagination import paginated, Pagination
@@ -28,7 +29,10 @@ class StudyListAPI(CRUDView):
             resource:
               Study
         """
-        q = Study.query
+        q = (Study.query.options(joinedload(Study.study_files)
+                                 .load_only('kf_id'))
+             .options(joinedload(Study.participants)
+                      .load_only('kf_id')))
 
         return (StudySchema(many=True)
                 .jsonify(Pagination(q, after, limit)))


### PR DESCRIPTION
This should have been done in #230 but I missed it. The default pagination behavior should have the optimization that only loads the kf_ids of child entities. This functionality was only being executed if a study_id query param was supplied. I moved it into the default query for pagination. 