### PR TITLE
🐛 Install python deps in venv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ RUN apk update && apk add py3-psycopg2 musl-dev \
  && pip install --upgrade pip \
  && pip install virtualenv
 
-RUN         pip install -r /app/requirements.txt
 ADD         . /app
-RUN         python /app/setup.py install
+RUN         virtualenv -p python3 venv && \
+            pip install -r /app/requirements.txt && \
+            python /app/setup.py install
 
 EXPOSE      80
 ENV         FLASK_APP "manage.py"


### PR DESCRIPTION
Was missing the setup of venv in the docker install, causing the service to fail if built in a directory without the venv already installed.