### PR TITLE
✨ Add SNS events for data changes

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,6 +27,8 @@ class Config:
 
     BUCKET_SERVICE_URL = os.environ.get('BUCKET_SERVICE_URL', None)
     BUCKET_SERVICE_TOKEN = os.environ.get('BUCKET_SERVICE_TOKEN', None)
+    SNS_EVENT_ARN = os.environ.get('SNS_EVENT_ARN',
+                                   'arn:aws:sns:*:123456789012:my_topic')
 
     @staticmethod
     def init_app(app):
@@ -46,12 +48,14 @@ class TestingConfig(Config):
     SQLALCHEMY_DATABASE_URI = 'postgres://postgres@localhost:5432/test'
     SQLALCHEMY_TRACK_MODIFICATIONS = True
 
+
     INDEXD_URL = os.environ.get('INDEXD_URL', '')
     BUCKET_SERVICE_URL = os.environ.get('BUCKET_SERVICE_URL', '')
     BUCKET_SERVICE_TOKEN = 'test123'
 
     MODEL_VERSION = '0.1.0'
     MIGRATION = 'aaaaaaaaaaaa'
+    SNS_EVENT_ARN = None
 
 
 class ProductionConfig(Config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ marshmallow-sqlalchemy==0.13.2
 psycopg2==2.7.3.2
 -e git+https://github.com/dankolbman/hvac#egg=hvac
 webargs==3.0.0
+boto3==1.7.8
+botocore==1.10.8

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,71 @@
+import json
+import pkg_resources
+import pytest
+
+from dataservice.api.common import id_service
+
+TOPIC_ARN = 'arn:aws:sns:*:123456789012:my_topic'
+
+
+class TestEvents:
+    """
+    Test that events are published to SNS with proper data
+    """
+
+    @pytest.mark.parametrize('endpoint,method', [
+        ('/sequencing-experiments', 'GET'),
+        ('/sequencing-centers', 'GET'),
+        ('/biospecimens', 'GET'),
+        ('/diagnoses', 'GET'),
+        ('/phenotypes', 'GET'),
+        ('/participants', 'GET'),
+        ('/studies', 'GET'),
+        ('/study-files', 'GET'),
+        ('/investigators', 'GET'),
+        ('/outcomes', 'GET'),
+        ('/families', 'GET'),
+        ('/family-relationships', 'GET'),
+        ('/genomic-files', 'GET')
+    ])
+    def test_no_message(self, app, client, mocker, endpoint, method):
+        """ Test that message is sent with right path """
+        app.config['SNS_EVENT_ARN'] = TOPIC_ARN
+        mock = mocker.patch('dataservice.api.common.views.boto3.client')
+        call_func = getattr(client, method.lower())
+        resp = call_func(endpoint)
+        assert mock().publish.call_count == 0
+        app.config['SNS_EVENT_ARN'] = None
+
+    @pytest.mark.parametrize('endpoint,method,data', [
+        ('/studies', 'POST', {'external_id': 'blah'}),
+    ])
+    def test_message(self, app, client, mocker, endpoint, method, data):
+        """ Test that message is sent with right path """
+        app.config['SNS_EVENT_ARN'] = TOPIC_ARN
+        mock = mocker.patch('dataservice.api.common.views.boto3.client')
+
+        call_func = getattr(client, method.lower())
+        resp = call_func(endpoint,
+                         data=json.dumps(data),
+                         headers={'Content-Type': 'application/json'})
+
+        assert mock().publish.call_count == 1
+
+        api_status = json.loads(client.get('/status').data.decode('utf-8'))
+        api_version = api_status['_status']['version']
+        api_commit = api_status['_status']['commit']
+
+        expected = {'default': json.dumps({
+            'path': endpoint,
+            'method': method.lower(),
+            'api_version': api_version,
+            'api_commit': api_commit,
+            'data': json.loads(resp.data)
+        })}
+
+        args = mock().publish.call_args_list[0]
+        message = json.loads(args[1]['Message'])
+        assert message == expected
+        assert args[1]['MessageStructure'] == 'json'
+        assert args[1]['TopicArn'] == TOPIC_ARN
+        app.config['SNS_EVENT_ARN'] = None


### PR DESCRIPTION
Adds ability to send API responses to SNS to alert and store any modifications of the data.

Currently sends:
- `POST`, `PATCH`, `PUT`, `DELETE` operations
- `path`, `method`, and response `data`