### PR TITLE
✨ Move acl to root document

### DIFF
--- a/dataservice/api/common/model.py
+++ b/dataservice/api/common/model.py
@@ -78,6 +78,7 @@ class IndexdFile:
     urls = []
     rev = None
     hashes = {}
+    acl = []
     # The metadata property is already used by sqlalchemy
     _metadata = {}
     size = None

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -81,6 +81,7 @@ class BaseSchema(ma.ModelSchema):
 
 class IndexdFileSchema(Schema):
     urls = ma.List(ma.Str(), required=True)
+    acl = ma.List(ma.Str(), required=False)
     file_name = ma.Str()
     hashes = ma.Dict(required=True)
     metadata = ma.Dict(attribute='_metadata')

--- a/dataservice/extensions/flask_indexd.py
+++ b/dataservice/extensions/flask_indexd.py
@@ -77,6 +77,7 @@ class Indexd(object):
 
           {
             "file_name": "my_file",
+            "acl": ["phs000000"],
             "hashes": {
               "md5": "0b7940593044dff8e74380476b2b27a9"
             },
@@ -85,7 +86,6 @@ class Indexd(object):
               "s3://mybucket/mykey/"
             ],
             "metadata": {
-              "acls": "phs000000",
               "kf_id": "PT_00000000"
             }
           }
@@ -115,6 +115,7 @@ class Indexd(object):
             "size": record.size,
             "form": "object",
             "hashes": record.hashes,
+            "acl": record.acl,
             "urls": record.urls,
             "metadata": meta
         }
@@ -155,6 +156,7 @@ class Indexd(object):
             "file_name": record.file_name,
             "size": record.size,
             "hashes": record.hashes,
+            "acl": record.acl,
             "urls": record.urls,
             "metadata": record._metadata
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ def entities(client, indexd):
             'urls': ['s3://bucket/key'],
             'hashes': {'md5': str(uuid.uuid4())},
             'controlled_access': False,
+            'acl': ['TEST01'],
             'availability': 'availble for download'
         },
         '/studies': {

--- a/tests/genomic_file/test_genomic_file_resources.py
+++ b/tests/genomic_file/test_genomic_file_resources.py
@@ -58,6 +58,7 @@ def test_new_indexd_error(client, entities):
         'external_id': 'genomic_file_0',
         'file_name': 'hg38.bam',
         'size': 123,
+        'acl': ['TEST'],
         'data_type': 'aligned reads',
         'file_format': 'bam',
         'urls': ['s3://bucket/key'],
@@ -137,6 +138,7 @@ def test_get_one(client, entities):
     assert resp['metadata'] == gf._metadata
     assert 'rev' not in resp
     assert resp['size'] == gf.size
+    assert resp['acl'] == gf.acl
     # check properties from datamodel
     assert resp['file_name'] == gf.file_name
     assert resp['data_type'] == gf.data_type


### PR DESCRIPTION
Indexd has moved the acl field from within metadata to the root of the document object.