### PR TITLE
🐛 Use the db session by default in all base schemas

### DIFF
--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -7,8 +7,9 @@ from marshmallow import (
     ValidationError
 )
 from flask import url_for, request
-from dataservice.api.common.pagination import Pagination
 from flask_marshmallow import Schema
+from dataservice.api.common.pagination import Pagination
+from dataservice.extensions import db
 
 
 class BaseSchema(ma.ModelSchema):
@@ -18,6 +19,9 @@ class BaseSchema(ma.ModelSchema):
     def __init__(self, code=200, message='success', *args, **kwargs):
         self.status_code = code
         self.status_message = message
+        # Add the request's db session to serializer if one is not specified
+        if 'session' not in kwargs:
+            kwargs['session'] = db.session
         super(BaseSchema, self).__init__(*args, **kwargs)
 
     class Meta:

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -1,9 +1,11 @@
+import re
 from dataservice.extensions import ma
 from marshmallow import (
     fields,
     post_dump,
     pre_dump,
     validates_schema,
+    validates,
     ValidationError
 )
 from flask import url_for, request
@@ -34,6 +36,14 @@ class BaseSchema(ma.ModelSchema):
             self.__pagination__ = data
             return data.items
         return data
+
+    @validates('kf_id')
+    def valid(self, value):
+        prefix = self.Meta.model.__prefix__
+        r = r'^'+prefix+r'_[A-HJ-KM-NP-TV-Z0-9]{8}'
+        m = re.search(r, value)
+        if not m:
+            raise ValidationError('Invalid kf_id')
 
     @post_dump(pass_many=True)
     def wrap_envelope(self, data, many):

--- a/tests/participant/test_participant_resources.py
+++ b/tests/participant/test_participant_resources.py
@@ -43,6 +43,38 @@ class ParticipantTest(FlaskTestCase):
         self.assertEqual(p.ethnicity, participant['ethnicity'])
         self.assertEqual(p.gender, participant['gender'])
 
+    def test_post_with_kf_id(self):
+        """
+        Test creating a new participant with a predetermined kf_id
+        """
+        s = Study(external_id='phs001')
+        db.session.add(s)
+        db.session.commit()
+
+        body = {
+            'kf_id': 'PT_00000000',
+            'external_id': 'test',
+            'is_proband': True,
+            'consent_type': 'GRU-IRB',
+            'race': 'asian',
+            'ethnicity': 'not hispanic',
+            'gender': 'female',
+            'study_id': s.kf_id
+        }
+
+        response = self.client.post(url_for(PARTICIPANT_LIST_URL),
+                                    headers=self._api_headers(),
+                                    data=json.dumps(body))
+
+        resp = json.loads(response.data.decode("utf-8"))
+        self.assertEqual(response.status_code, 201)
+
+        self.assertEqual(resp['results']['kf_id'], 'PT_00000000')
+
+        p = Participant.query.first()
+        self.assertEqual(p.kf_id, resp['results']['kf_id'])
+        self.assertEqual(p.kf_id, 'PT_00000000')
+
     def test_post_missing_req_params(self):
         """
         Test create participant that is missing required parameters in body

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -148,6 +148,17 @@ class TestAPI:
                            headers={'Content-Type': 'application/json'})
         assert resp.status_code != 500
 
+    @pytest.mark.parametrize('endpoint', ENDPOINTS)
+    @pytest.mark.parametrize('kf_id', ['XX_00000000', 'SD_ILOU0000', 'SD_01'])
+    def test_malformed_predefined_kf_id(self, client, endpoint, kf_id):
+        """ Check that posting malformed predefined kf_id doesn't 500 """
+        resp = client.post(endpoint,
+                data=json.dumps({'kf_id': kf_id, 'external_id': 'blah'}),
+                           headers={'Content-Type': 'application/json'})
+        assert resp.status_code == 400
+        resp = json.loads(resp.data.decode('utf-8'))
+        assert 'Invalid kf_id' in resp['_status']['message']
+
 
     @pytest.mark.parametrize('field', ['uuid'])
     @pytest.mark.parametrize('endpoint', ENDPOINTS)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -140,6 +140,15 @@ class TestAPI:
             assert (field not in body['results']
                     or body['results'][field] != 'test')
 
+    @pytest.mark.parametrize('endpoint', ENDPOINTS)
+    def test_predefined_kf_id(self, client, endpoint):
+        """ Check that posting predefined kf_id doesn't 500 """
+        resp = client.post(endpoint,
+                           data=json.dumps({'kf_id': 'XX_00000000'}),
+                           headers={'Content-Type': 'application/json'})
+        assert resp.status_code != 500
+
+
     @pytest.mark.parametrize('field', ['uuid'])
     @pytest.mark.parametrize('endpoint', ENDPOINTS)
     def test_excluded_field(self, client, entities, field, endpoint):

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,5 +1,6 @@
 import pytest
 import random
+import re
 import string
 from dataservice.api.common.model import Base
 from dataservice.api.common.id_service import uuid_generator, kf_id_generator
@@ -25,6 +26,7 @@ def test_kf_id():
         assert 'O' not in kf_id[2:]
         assert 'U' not in kf_id[2:]
 
+        assert re.search(r'^'+prefix+r'_[A-HJ-KM-NP-TV-Z0-9]{8}', kf_id)
 
 def test_kf_id_field(client):
     from dataservice.extensions import db


### PR DESCRIPTION
Entities may be created with the `kf_id` being specified up front.
Fixes #307 
Fixes #295 