### PR TITLE
🐛 Ignore mime type when parsing request body

### DIFF
--- a/dataservice/api/biospecimen/resources.py
+++ b/dataservice/api/biospecimen/resources.py
@@ -55,7 +55,7 @@ class BiospecimenListAPI(CRUDView):
               Biospecimen
         """
 
-        body = request.json
+        body = request.get_json(force=True)
 
         # Deserialize
         try:

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -88,6 +88,8 @@ class BaseSchema(ma.ModelSchema):
 
     @validates_schema(pass_original=True)
     def check_unknown_fields(self, data, original_data):
+        if data is None:
+            return
         unknown = set(original_data) - set(self.fields)
         if unknown:
             raise ValidationError('Unknown field', unknown)

--- a/dataservice/api/diagnosis/resources.py
+++ b/dataservice/api/diagnosis/resources.py
@@ -53,7 +53,7 @@ class DiagnosisListAPI(CRUDView):
               Diagnosis
         """
 
-        body = request.json
+        body = request.get_json(force=True)
 
         # Deserialize
         try:
@@ -113,7 +113,7 @@ class DiagnosisAPI(CRUDView):
                   .format('diagnosis', kf_id))
 
         # Partial update - validate but allow missing required fields
-        body = request.json or {}
+        body = request.get_json(force=True) or {}
         try:
             dg = DiagnosisSchema(strict=True).load(body, instance=dg,
                                                    partial=True).data

--- a/dataservice/api/family/resources.py
+++ b/dataservice/api/family/resources.py
@@ -54,8 +54,9 @@ class FamilyListAPI(CRUDView):
             resource:
               Family
         """
+        body = request.get_json(force=True)
         try:
-            fam = FamilySchema(strict=True).load(request.json).data
+            fam = FamilySchema(strict=True).load(body).data
         except ValidationError as err:
             abort(400, 'could not create family: {}'.format(err.messages))
 
@@ -109,7 +110,7 @@ class FamilyAPI(CRUDView):
                   .format('family', kf_id))
 
         # Partial update - validate but allow missing required fields
-        body = request.json or {}
+        body = request.get_json(force=True) or {}
         try:
             fam = FamilySchema(strict=True).load(body, instance=fam,
                                                  partial=True).data

--- a/dataservice/api/family_relationship/resources.py
+++ b/dataservice/api/family_relationship/resources.py
@@ -55,7 +55,7 @@ class FamilyRelationshipListAPI(CRUDView):
               FamilyRelationship
         """
 
-        body = request.json
+        body = request.get_json(force=True)
 
         # Deserialize
         try:
@@ -118,7 +118,7 @@ class FamilyRelationshipAPI(CRUDView):
                   .format('family_relationship', kf_id))
 
         # Partial update - validate but allow missing required fields
-        body = request.json or {}
+        body = request.get_json(force=True) or {}
         try:
             fr = FamilyRelationshipSchema(strict=True).load(body, instance=fr,
                                                             partial=True).data

--- a/dataservice/api/genomic_file/resources.py
+++ b/dataservice/api/genomic_file/resources.py
@@ -59,8 +59,9 @@ class GenomicFileListAPI(CRUDView):
             resource:
               GenomicFile
         """
+        body = request.get_json(force=True)
         try:
-            gf = GenomicFileSchema(strict=True).load(request.json).data
+            gf = GenomicFileSchema(strict=True).load(body).data
         except ValidationError as err:
             abort(400,
                   'could not create genomic_file: {}'.format(err.messages))
@@ -117,7 +118,7 @@ class GenomicFileAPI(CRUDView):
             resource:
               GenomicFile
         """
-        body = request.json or {}
+        body = request.get_json(force=True) or {}
         gf = GenomicFile.query.get(kf_id)
         if gf is None:
             abort(404, 'could not find {} `{}`'

--- a/dataservice/api/investigator/resources.py
+++ b/dataservice/api/investigator/resources.py
@@ -54,8 +54,9 @@ class InvestigatorListAPI(CRUDView):
             resource:
               Investigator
         """
+        body = request.get_json(force=True)
         try:
-            inv = InvestigatorSchema(strict=True).load(request.json).data
+            inv = InvestigatorSchema(strict=True).load(body).data
         except ValidationError as err:
             abort(400,
                   'could not create investigator: {}'.format(err.messages))
@@ -103,7 +104,7 @@ class InvestigatorAPI(CRUDView):
             resource:
               Investigator
         """
-        body = request.json
+        body = request.get_json(force=True)
         inv = Investigator.query.get(kf_id)
         if inv is None:
             abort(404, 'could not find {} `{}`'

--- a/dataservice/api/outcome/resources.py
+++ b/dataservice/api/outcome/resources.py
@@ -54,7 +54,7 @@ class OutcomeListAPI(CRUDView):
               Outcome
         """
 
-        body = request.json
+        body = request.get_json(force=True)
 
         # Deserialize
         try:
@@ -117,7 +117,7 @@ class OutcomeAPI(CRUDView):
         if o is None:
             abort(404, 'could not find {} `{}`'.format('outcome', kf_id))
         # Partial update - validate but allow missing required fields
-        body = request.json or {}
+        body = request.get_json(force=True) or {}
         # Validation only
         try:
             o = OutcomeSchema(strict=True).load(body, instance=o,

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -58,8 +58,9 @@ class ParticipantListAPI(CRUDView):
             resource:
               Participant
         """
+        body = request.get_json(force=True)
         try:
-            p = ParticipantSchema(strict=True).load(request.json).data
+            p = ParticipantSchema(strict=True).load(body).data
         except ValidationError as err:
             abort(400, 'could not create participant: {}'.format(err.messages))
 
@@ -113,7 +114,7 @@ class ParticipantAPI(CRUDView):
                   .format('participant', kf_id))
 
         # Partial update - validate but allow missing required fields
-        body = request.json or {}
+        body = request.get_json(force=True) or {}
         try:
             p = ParticipantSchema(strict=True).load(body, instance=p,
                                                     partial=True).data

--- a/dataservice/api/phenotype/resources.py
+++ b/dataservice/api/phenotype/resources.py
@@ -53,7 +53,7 @@ class PhenotypeListAPI(CRUDView):
               Phenotype
         """
 
-        body = request.json
+        body = request.get_json(force=True)
 
         # Deserialize
         try:
@@ -110,7 +110,7 @@ class PhenotypeAPI(CRUDView):
             resource:
               Phenotype
         """
-        body = request.json or {}
+        body = request.get_json(force=True) or {}
         # Check if phenotype exists
         p = Phenotype.query.get(kf_id)
         # Not found in database

--- a/dataservice/api/sequencing_center/resources.py
+++ b/dataservice/api/sequencing_center/resources.py
@@ -61,7 +61,7 @@ class SequencingCenterListAPI(CRUDView):
               SequencingCenter
         """
 
-        body = request.json
+        body = request.get_json(force=True)
 
         # Deserialize
         try:
@@ -125,7 +125,7 @@ class SequencingCenterAPI(CRUDView):
                   .format('sequencing_center', kf_id))
 
         # Partial update - validate but allow missing required fields
-        body = request.json or {}
+        body = request.get_json(force=True) or {}
         try:
             se = (SequencingCenterSchema(strict=True).
                   load(body, instance=se,

--- a/dataservice/api/sequencing_experiment/resources.py
+++ b/dataservice/api/sequencing_experiment/resources.py
@@ -63,7 +63,7 @@ class SequencingExperimentListAPI(CRUDView):
               SequencingExperiment
         """
 
-        body = request.json
+        body = request.get_json(force=True)
 
         # Deserialize
         try:
@@ -127,7 +127,7 @@ class SequencingExperimentAPI(CRUDView):
                   .format('sequencing_experiment', kf_id))
 
         # Partial update - validate but allow missing required fields
-        body = request.json or {}
+        body = request.get_json(force=True) or {}
         try:
             se = (SequencingExperimentSchema(strict=True).
                   load(body, instance=se,

--- a/dataservice/api/study/resources.py
+++ b/dataservice/api/study/resources.py
@@ -48,8 +48,9 @@ class StudyListAPI(CRUDView):
             resource:
               Study
         """
+        body = request.get_json(force=True)
         try:
-            st = StudySchema(strict=True).load(request.json).data
+            st = StudySchema(strict=True).load(body).data
         except ValidationError as err:
             abort(400, 'could not create study: {}'.format(err.messages))
 
@@ -96,7 +97,7 @@ class StudyAPI(CRUDView):
             resource:
               Study
         """
-        body = request.json
+        body = request.get_json(force=True)
         st = Study.query.get(kf_id)
         if st is None:
             abort(404, 'could not find {} `{}`'

--- a/dataservice/api/study_file/resources.py
+++ b/dataservice/api/study_file/resources.py
@@ -51,8 +51,9 @@ class StudyFileListAPI(CRUDView):
             resource:
               StudyFile
         """
+        body = request.get_json(force=True)
         try:
-            st = StudyFileSchema(strict=True).load(request.json).data
+            st = StudyFileSchema(strict=True).load(body).data
         except ValidationError as err:
             abort(400, 'could not create study_file: {}'.format(err.messages))
         db.session.add(st)
@@ -105,7 +106,7 @@ class StudyFileAPI(CRUDView):
             resource:
               StudyFile
         """
-        body = request.json
+        body = request.get_json(force=True)
         st = StudyFile.query.get(kf_id)
         if st is None:
             abort(404, 'could not find {} `{}`'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,6 +33,14 @@ class TestAPI:
     and header checks
     """
 
+    @pytest.mark.parametrize('endpoint', ENDPOINTS)
+    def test_no_content_type(self, client, endpoint):
+        """ Test that no 500 is thrown when the content isnt specified """
+        resp = client.post(endpoint, data='{}')
+        assert resp.status_code < 500
+        resp = client.patch(endpoint, data='{}')
+        assert resp.status_code < 500
+
     @pytest.mark.parametrize('endpoint,method,status_code',
                              [(ept, 'GET', 200) for ept in ENDPOINTS] +
                              [(ept+'/123', 'GET', 404) for ept in ENDPOINTS]
@@ -63,7 +71,7 @@ class TestAPI:
         returned from the server contains a given string
         """
         call_func = getattr(client, method.lower())
-        resp = call_func(endpoint)
+        resp = call_func(endpoint, data='{}')
         resp = json.loads(resp.data.decode('utf-8'))
         assert resp['_status']['message'].startswith(status_message)
 


### PR DESCRIPTION
API was returning 500 whenever the `Content-Type` wasn't specified as `application/json`. This will force the body to be read as json and won't attempt to validate unexpected fields when there is no body.