### PR TITLE
🔧 Bucket secret default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="kf-api-dataservice",
-    version="1.0.0",
+    version="1.0.1",
     description="Data Service API",
     license="Apache 2",
     packages=find_packages()


### PR DESCRIPTION
Won't try to load the bucket secret from vault if not in environment, or the secret in vault is empty.