### PR TITLE
🐛Fix paginated endpoints

### DIFF
--- a/dataservice/api/biospecimen/resources.py
+++ b/dataservice/api/biospecimen/resources.py
@@ -41,9 +41,7 @@ class BiospecimenListAPI(CRUDView):
 
         # Apply filter params
         q = (Biospecimen.query
-             .filter_by(**filter_params)
-             .options(joinedload(Biospecimen.genomic_files)
-                      .load_only('kf_id')))
+             .filter_by(**filter_params))
 
         # Apply study filter param
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/cavatica_app/resources.py
+++ b/dataservice/api/cavatica_app/resources.py
@@ -38,9 +38,7 @@ class CavaticaAppListAPI(CRUDView):
         # Get study id and remove from model filter params
         study_id = filter_params.pop('study_id', None)
 
-        q = (CavaticaApp.query.filter_by(**filter_params)
-             .options(joinedload(CavaticaApp.cavatica_tasks)
-                      .load_only('kf_id')))
+        q = (CavaticaApp.query.filter_by(**filter_params))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/cavatica_task/resources.py
+++ b/dataservice/api/cavatica_task/resources.py
@@ -39,10 +39,7 @@ class CavaticaTaskListAPI(CRUDView):
         study_id = filter_params.pop('study_id', None)
 
         q = (CavaticaTask.query
-             .filter_by(**filter_params)
-             .options(joinedload(
-                 CavaticaTask.cavatica_task_genomic_files)
-                 .load_only('kf_id')))
+             .filter_by(**filter_params))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/family/resources.py
+++ b/dataservice/api/family/resources.py
@@ -37,9 +37,7 @@ class FamilyListAPI(CRUDView):
         study_id = filter_params.pop('study_id', None)
 
         q = (Family.query
-             .filter_by(**filter_params)
-             .options(joinedload(Family.participants)
-                      .load_only('kf_id')))
+             .filter_by(**filter_params))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/genomic_file/resources.py
+++ b/dataservice/api/genomic_file/resources.py
@@ -43,10 +43,7 @@ class GenomicFileListAPI(CRUDView):
 
         # Get a page of the data from the model first
         q = (GenomicFile.query
-             .filter_by(**filter_params)
-             .options(joinedload(
-                 GenomicFile.cavatica_task_genomic_files)
-                 .load_only('kf_id')))
+             .filter_by(**filter_params))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/investigator/resources.py
+++ b/dataservice/api/investigator/resources.py
@@ -40,10 +40,7 @@ class InvestigatorListAPI(CRUDView):
         study_id = filter_params.pop('study_id', None)
 
         q = (Investigator.query
-             .filter_by(**filter_params)
-             .options(
-                 joinedload(Investigator.studies)
-                 .load_only('kf_id')))
+             .filter_by(**filter_params))
 
         # Filter by study
         from dataservice.api.study.models import Study

--- a/dataservice/api/participant/resources.py
+++ b/dataservice/api/participant/resources.py
@@ -36,15 +36,7 @@ class ParticipantListAPI(CRUDView):
               Participant
         """
         # Apply entity filter params
-        q = (Participant.query.filter_by(**filter_params)
-                        .options(joinedload(Participant.diagnoses)
-                                 .load_only('kf_id'))
-                        .options(joinedload(Participant.biospecimens)
-                                 .load_only('kf_id'))
-                        .options(joinedload(Participant.phenotypes)
-                                 .load_only('kf_id'))
-                        .options(joinedload(Participant.outcomes)
-                                 .load_only('kf_id')))
+        q = (Participant.query.filter_by(**filter_params))
 
         return (ParticipantSchema(many=True)
                 .jsonify(Pagination(q, after, limit)))

--- a/dataservice/api/sequencing_center/resources.py
+++ b/dataservice/api/sequencing_center/resources.py
@@ -40,11 +40,7 @@ class SequencingCenterListAPI(CRUDView):
         study_id = filter_params.pop('study_id', None)
 
         q = (SequencingCenter.query
-             .filter_by(**filter_params)
-             .options(joinedload(SequencingCenter.biospecimens)
-                      .load_only('kf_id'))
-             .options(joinedload(SequencingCenter.sequencing_experiments).
-                      load_only('kf_id')))
+             .filter_by(**filter_params))
         # Filter by study
         from dataservice.api.participant.models import Participant
         from dataservice.api.biospecimen.models import Biospecimen

--- a/dataservice/api/sequencing_center/resources.py
+++ b/dataservice/api/sequencing_center/resources.py
@@ -1,6 +1,5 @@
 from flask import abort, request
 from marshmallow import ValidationError
-from sqlalchemy.orm import joinedload
 from webargs.flaskparser import use_args
 
 from dataservice.extensions import db

--- a/dataservice/api/sequencing_experiment/resources.py
+++ b/dataservice/api/sequencing_experiment/resources.py
@@ -40,10 +40,7 @@ class SequencingExperimentListAPI(CRUDView):
         study_id = filter_params.pop('study_id', None)
 
         q = (SequencingExperiment.query
-             .filter_by(**filter_params)
-             .options(
-                 joinedload(SequencingExperiment.genomic_files)
-                 .load_only('kf_id')))
+             .filter_by(**filter_params))
 
         # Filter by study
         from dataservice.api.participant.models import Participant

--- a/dataservice/api/study/resources.py
+++ b/dataservice/api/study/resources.py
@@ -34,11 +34,7 @@ class StudyListAPI(CRUDView):
               Study
         """
         q = (Study.query
-             .filter_by(**filter_params)
-             .options(joinedload(Study.study_files)
-                      .load_only('kf_id'))
-             .options(joinedload(Study.participants)
-                      .load_only('kf_id')))
+             .filter_by(**filter_params))
 
         return (StudySchema(many=True)
                 .jsonify(Pagination(q, after, limit)))


### PR DESCRIPTION
Addresses #296 

Removed the joined load of children entities in paginated endpoints. 

### Problem
This was needed before since all the paginated endpoints were querying for children entities and returning a list of the children's kf ids in the response. This affected `sequencing_center` the most because doing a `GET /sequencing-centers` essentially resulted in a joined load of every single genomic file and sequencing experiment (since every one of these entities has a seq center). None of the other entities have this many children, and thus, none of the other entities paginated endpoints suffered from timeouts.

### Solution
Since we no longer return children ids in the paginated endpoints, there is no need to join the children with the parent on a simple select all query for the entity of interest. 

### Testing
Local testing didn't catch this because not enough data was there to cause the problem. I tested this solution in the deployed dev environment. Before the fix I was getting 500+ errors on `GET /sequencing-centers`, with just the Chung study loaded. After the fix I loaded Chung, Schiffman, Seidman, and Rios and was able to successfully retrieve sequencing centers.

Example code fix:

This 
```python
q = (SequencingCenter.query
             .filter_by(**filter_params)
             .options(joinedload(SequencingCenter.biospecimens)
                      .load_only('kf_id'))
             .options(joinedload(SequencingCenter.sequencing_experiments).
                      load_only('kf_id')))
```

Changed to:
```python
q = (SequencingCenter.query
             .filter_by(**filter_params))
```