### PR TITLE
🔧 Increase number of workers

### DIFF
--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -25,6 +25,6 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:gunicorn]
-command=gunicorn manage:app -b localhost:5000
+command=gunicorn manage:app -b localhost:5000 --workers 2
 stderr_logfile=/dev/stdout
 stderr_logfile_maxbytes=0


### PR DESCRIPTION
We are currently maxing out our containers at %50 CPU, so we should easily accommodate another worker. This is the CPU load from highly concurrent requests:
![screen shot 2018-05-23 at 8 56 48 am](https://user-images.githubusercontent.com/2495894/40425770-4d4cdcc0-5e67-11e8-9c4e-b06fbb3ad825.png)
