### PR TITLE
🐛 Fix repeated loading of jinja tempaltes

### DIFF
--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -25,6 +25,6 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:gunicorn]
-command=gunicorn manage:app -b localhost:5000 --workers 5
+command=gunicorn manage:app -b localhost:5000 --workers 3
 stderr_logfile=/dev/stdout
 stderr_logfile_maxbytes=0

--- a/dataservice/api/common/views.py
+++ b/dataservice/api/common/views.py
@@ -28,6 +28,9 @@ class CRUDView(MethodView):
     schemas = {}
     endpoint = None
     rule = '/'
+    temp_env = jinja2.Environment(
+            loader=jinja2.PackageLoader('dataservice.api', 'templates')
+    )
 
     def __init__(self, *args, **kwargs):
         super(CRUDView, self).__init__(*args, **kwargs)
@@ -159,10 +162,7 @@ class CRUDView(MethodView):
         """
         Renders a yaml file templated with jinja2 and deserializes to a dict
         """
-        env = jinja2.Environment(
-            loader=jinja2.PackageLoader('dataservice.api', 'templates')
-        )
-        template = env.get_template(template_name)
+        template = CRUDView.temp_env.get_template(template_name)
         return yaml.safe_load(template.render(**props))
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Flask-Migrate==2.1.1
 Flask-Profile==0.2
 Flask-SQLAlchemy==2.3.2
 itsdangerous==0.24
-Jinja2==2.8
 Mako==1.0.4
 MarkupSafe==0.23
 python-editor==1.0.3
@@ -24,3 +23,4 @@ psycopg2==2.7.3.2
 webargs==3.0.0
 boto3==1.7.8
 botocore==1.10.8
+Jinja2==2.10


### PR DESCRIPTION
Loading templates from the filesystem repeatedly was causing issues with concurrent reads from many gunicorn workers. This was possibly preventing gunicorn from starting > 1 worker.