### PR TITLE
✨ Patch acl

### DIFF
--- a/dataservice/api/common/pagination.py
+++ b/dataservice/api/common/pagination.py
@@ -115,11 +115,10 @@ def indexd_pagination(q, after, limit):
         pager = Pagination(q, next_after, remain)
 
         for st in pager.items:
-            merged = st.merge_indexd()
-            if merged is not None:
-                keep.append(st)
-            else:
+            if hasattr(st, 'was_deleted') and st.was_deleted:
                 refresh = True
+            else:
+                keep.append(st)
 
     # Replace original page's items with new list of valid files
     pager.items = keep

--- a/dataservice/api/genomic_file/resources.py
+++ b/dataservice/api/genomic_file/resources.py
@@ -108,12 +108,6 @@ class GenomicFileAPI(CRUDView):
             abort(404, 'could not find {} `{}`'
                   .format('genomic_file', kf_id))
 
-        # Merge will return None if the document wasnt found in indexd
-        merge = genomic_file.merge_indexd()
-        if merge is None:
-            abort(404, 'could not find {} `{}`'
-                  .format('genomic_file', kf_id))
-
         sch = GenomicFileSchema(many=False)
         return sch.jsonify(genomic_file)
 
@@ -131,12 +125,6 @@ class GenomicFileAPI(CRUDView):
         body = request.get_json(force=True) or {}
         gf = GenomicFile.query.get(kf_id)
         if gf is None:
-            abort(404, 'could not find {} `{}`'
-                  .format('genomic_file', kf_id))
-
-        # Fetch fields from indexd first
-        merge = gf.merge_indexd()
-        if merge is None:
             abort(404, 'could not find {} `{}`'
                   .format('genomic_file', kf_id))
 

--- a/dataservice/api/study_file/resources.py
+++ b/dataservice/api/study_file/resources.py
@@ -88,12 +88,6 @@ class StudyFileAPI(CRUDView):
             abort(404, 'could not find {} `{}`'
                   .format('study_file', kf_id))
 
-        # Merge will return None if the document wasnt found in indexd
-        merge = st.merge_indexd()
-        if merge is None:
-            abort(404, 'could not find {} `{}`'
-                  .format('study_file', kf_id))
-
         return StudyFileSchema(many=False).jsonify(st)
 
     def patch(self, kf_id):
@@ -110,12 +104,6 @@ class StudyFileAPI(CRUDView):
         body = request.get_json(force=True)
         st = StudyFile.query.get(kf_id)
         if st is None:
-            abort(404, 'could not find {} `{}`'
-                  .format('study_file', kf_id))
-
-        # Fetch fields from indexd first
-        merge = st.merge_indexd()
-        if merge is None:
             abort(404, 'could not find {} `{}`'
                   .format('study_file', kf_id))
 

--- a/tests/genomic_file/test_genomic_file_models.py
+++ b/tests/genomic_file/test_genomic_file_models.py
@@ -168,9 +168,8 @@ class ModelTest(IndexdTestCase):
 
         expected = {
             'file_name': 'hg38.bam',
-            'size': 1234,
             'form': 'object',
-            'hashes': {'md5': 'dcff06ebb19bc9aa8f1aae1288d10dc2'},
+            'size': 1234,
             'acl': ["new_acl"],
             'urls': ['s3://bucket/key'],
             'metadata': {'test': 'test'}
@@ -197,18 +196,16 @@ class ModelTest(IndexdTestCase):
         gf = GenomicFile.query.get(kwargs['kf_id'])
         assert gf.acl == ['INTERNAL', 'new_acl']
 
-        assert self.indexd.Session().post.call_count == 3
+        # Update document and all versions
+        assert self.indexd.Session().put.call_count == 4
 
         expected = {
             'file_name': 'hg38.bam',
-            'size': 7696048,
-            'form': 'object',
-            'hashes': {'md5': 'dcff06ebb19bc9aa8f1aae1288d10dc2'},
             'acl': ['INTERNAL', 'new_acl'],
             'urls': ['s3://bucket/key'],
             'metadata': {}
         }
-        self.indexd.Session().post.assert_any_call(
+        self.indexd.Session().put.assert_any_call(
                 '{}?rev={}'.format(did, gf.rev), json=expected)
 
     def test_delete(self):

--- a/tests/genomic_file/test_genomic_file_resources.py
+++ b/tests/genomic_file/test_genomic_file_resources.py
@@ -73,6 +73,7 @@ def genomic_files(client, entities):
     gfs = [GenomicFile(**props) for _ in range(EXPECTED_TOTAL - ENTITY_TOTAL)]
     db.session.add_all(gfs)
     db.session.commit()
+    db.session.expunge_all()
 
 
 def test_new(client, indexd, entities):
@@ -131,7 +132,7 @@ def test_get_list(client, indexd, genomic_files):
     assert resp['_status']['code'] == 200
     assert resp['total'] == GenomicFile.query.count()
     assert len(resp['results']) == 10
-    assert indexd.get.call_count == 11
+    assert indexd.get.call_count == 10
 
 
 def test_get_list_with_missing_files(client, indexd, genomic_files):
@@ -158,7 +159,7 @@ def test_get_list_with_missing_files(client, indexd, genomic_files):
     assert len(resp['results']) == 0
     for res in resp['results']:
         assert 'kf_id' in res
-    expected = (EXPECTED_TOTAL - ENTITY_TOTAL)*2 + ENTITY_TOTAL
+    expected = EXPECTED_TOTAL
     assert indexd.get.call_count == expected 
 
 

--- a/tests/genomic_file/test_genomic_file_resources.py
+++ b/tests/genomic_file/test_genomic_file_resources.py
@@ -18,7 +18,7 @@ from tests.mocks import MockIndexd
 
 GENOMICFILE_URL = 'api.genomic_files'
 GENOMICFILE_LIST_URL = 'api.genomic_files_list'
-EXPECTED_TOTAL = ENTITY_TOTAL + 102
+EXPECTED_TOTAL = ENTITY_TOTAL + 102*2
 
 
 @pytest.fixture(scope='function')
@@ -131,7 +131,7 @@ def test_get_list(client, indexd, genomic_files):
     assert resp['_status']['code'] == 200
     assert resp['total'] == GenomicFile.query.count()
     assert len(resp['results']) == 10
-    assert indexd.get.call_count == 10
+    assert indexd.get.call_count == 11
 
 
 def test_get_list_with_missing_files(client, indexd, genomic_files):
@@ -158,7 +158,8 @@ def test_get_list_with_missing_files(client, indexd, genomic_files):
     assert len(resp['results']) == 0
     for res in resp['results']:
         assert 'kf_id' in res
-    assert indexd.get.call_count == EXPECTED_TOTAL
+    expected = (EXPECTED_TOTAL - ENTITY_TOTAL)*2 + ENTITY_TOTAL
+    assert indexd.get.call_count == expected 
 
 
 def test_get_one(client, entities):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -87,9 +87,16 @@ class MockIndexd(MagicMock):
         """
         Mocks a response from GET /index/
         """
-        did = url.split('/')[-1].split('?')[0]
-        resp = self.doc.copy()
-        resp['did'] = did
+        if url.endswith('/versions'):
+            did = url.split('/')[-2]
+            resp = {}
+            for i in range(3):
+                resp[i] = self.doc.copy()
+                resp[i]['did'] = did if i == 0 else str(uuid.uuid4())
+        else:
+            did = url.split('/')[-1].split('?')[0]
+            resp = self.doc.copy()
+            resp['did'] = did
 
         return MockResp(resp=resp, status_code=self.status_code)
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -42,8 +42,8 @@ class MockIndexd(MagicMock):
             "md5": "dcff06ebb19bc9aa8f1aae1288d10dc2"
         },
         "metadata": {
-            "acls": "INTERNAL"
         },
+        "acl": ["INTERNAL"],
         "rev": "39b19b2d",
         "size": 7696048,
         "updated_date": "2018-02-21T00:44:27.414671",

--- a/tests/study_file/test_study_file_resources.py
+++ b/tests/study_file/test_study_file_resources.py
@@ -79,6 +79,7 @@ def study_files(client, entities):
         assert resp.status_code == 201
 
     assert StudyFile.query.count() == EXPECTED_TOTAL
+    db.session.expunge_all()
 
 
 @pytest.mark.usefixtures("indexd")
@@ -132,7 +133,7 @@ def test_get_list(client, indexd, study_files):
     assert resp['_status']['code'] == 200
     assert resp['total'] == StudyFile.query.count()
     assert len(resp['results']) == 10
-    assert indexd.get.call_count == 11
+    assert indexd.get.call_count == 10
 
 
 def test_get_list_with_missing_files(client, indexd, study_files):
@@ -159,7 +160,7 @@ def test_get_list_with_missing_files(client, indexd, study_files):
     assert len(resp['results']) == 0
     for res in resp['results']:
         assert 'kf_id' in res
-    expected = (EXPECTED_TOTAL - ENTITY_TOTAL)*2 + ENTITY_TOTAL
+    expected = EXPECTED_TOTAL
     assert indexd.get.call_count == expected 
 
 

--- a/tests/study_file/test_study_file_resources.py
+++ b/tests/study_file/test_study_file_resources.py
@@ -132,7 +132,7 @@ def test_get_list(client, indexd, study_files):
     assert resp['_status']['code'] == 200
     assert resp['total'] == StudyFile.query.count()
     assert len(resp['results']) == 10
-    assert indexd.get.call_count == 10
+    assert indexd.get.call_count == 11
 
 
 def test_get_list_with_missing_files(client, indexd, study_files):
@@ -159,7 +159,8 @@ def test_get_list_with_missing_files(client, indexd, study_files):
     assert len(resp['results']) == 0
     for res in resp['results']:
         assert 'kf_id' in res
-    assert indexd.get.call_count == EXPECTED_TOTAL
+    expected = (EXPECTED_TOTAL - ENTITY_TOTAL)*2 + ENTITY_TOTAL
+    assert indexd.get.call_count == expected 
 
 
 def test_get_one(client, entities):


### PR DESCRIPTION
Only creates a new version of a document when the `size` or `hashes` property changes. Otherwise modifies the existing document.
Also changes the acl of all versions of a document when the acl is changed.

Test script used to confirm that all versions are updated:

```
export API=localhost:5000

echo ""
echo "Make new GF"
export RESP=`curl -s -XPOST $API/genomic-files -d '{"file_name": "test", "acl": ["TEST"], "size": 1234, "hashes": {"md5": "f5d566687637ba7b0e529f465b102693"}, "urls": ["s3://test/key"]}'`
echo $RESP | jq '.results.kf_id' --raw-output
echo $RESP | jq '.results.latest_did' --raw-output
export GFID=`echo $RESP | jq '.results.kf_id' --raw-output`

echo ""
echo "Update GF size and hash"
export RESP=`curl -H "Content-Type: application/json" -XPATCH -s $API/genomic-files/$GFID -d '{"file_name": "test", "acl": ["TEST"], "size": 5678, "hashes": {"md5": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "urls": ["s3://test/key"]}'`
echo $RESP | jq '.results.kf_id' --raw-output
echo $RESP | jq '.results.latest_did' --raw-output

echo ""
echo "Update GF acl"
export RESP=`curl -H "Content-Type: application/json" -s -XPATCH $API/genomic-files/$GFID -d '{"file_name": "test", "acl": ["TEST", "TEST2"], "size": 5678, "hashes": { "md5": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "urls": ["s3://test/key"]}'`
echo $RESP | jq '.results.kf_id' --raw-output
echo $RESP | jq '.results.latest_did' --raw-output

echo ""
echo "Update GF name"
export RESP=`curl -H "Content-Type: application/json" -s -XPATCH $API/genomic-files/$GFID -d '{"file_name": "test revision", "acl": ["TEST", "TEST2"], "size": 5678, "hashes": { "md5": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "urls": ["s3://test/key"]}'`
echo $RESP | jq '.results.kf_id' --raw-output
echo $RESP | jq '.results.latest_did' --raw-output
```