### PR TITLE
🚑 Use explicit updates when update indexd fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
         environment:
         - POSTGRES_USER=postgres
         - POSTGRES_DB=test
+        - PG_USER=postgres
+        - PG_NAME=test
 
     working_directory: ~/repo
 
@@ -48,6 +50,8 @@ jobs:
             python-codacy-coverage -r coverage.xml
           environment:
             - FLASK_APP: "manage"
+            - PG_USER: "postgres"
+            - PG_NAME: "test"
 
       - store_artifacts:
           path: test-reports

--- a/config.py
+++ b/config.py
@@ -44,7 +44,7 @@ class TestingConfig(Config):
     SERVER_NAME = "localhost"
     TESTING = True
     WTF_CSRF_ENABLED = False
-    SQLALCHEMY_DATABASE_URI = 'postgres://postgres@localhost:5432/test'
+    # SQLALCHEMY_DATABASE_URI = 'postgres://postgres@localhost:5432/test'
     SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 

--- a/dataservice/api/common/model.py
+++ b/dataservice/api/common/model.py
@@ -42,33 +42,6 @@ class IDMixin:
     uuid = db.Column(UUID(), unique=True, default=uuid_generator)
 
 
-class IndexdField():
-
-    def __init__(self, value):
-        self._value = value
-
-    def __get__(self, instance, owner=None):
-        return self._value
-
-    def __set__(self, instance, value):
-        """
-        If the value is being changed on an object that is already being
-        stored in the database, the modifed_at column will be explicitly
-        update. This must be done so that the object in the database is
-        update and the ORM update event is triggered. Otherwise, the event
-        will not be triggered and the object will not be updated in Indexd.
-
-        NB: The value of the field may only be *set* through assignment.
-        Collection functions such as list.append() or dict.__setitem__()
-        will not trigger this hook when invoked.
-        """
-        if instance and not value == self._value:
-            state = inspect(instance)
-            if state.persistent:
-                instance.modified_at = datetime.now()
-        self._value = value
-
-
 class IndexdFile:
     """
     Field reflection for objects that are stored in indexd
@@ -104,21 +77,36 @@ class IndexdFile:
     # files in indexd cannot be looked up by their baseid
     latest_did = db.Column(UUID(), nullable=False)
 
-    # Fields used by indexd, but not tracked in the database
-    file_name = IndexdField('')
-    urls = IndexdField([])
+    file_name = ''
+    urls = []
     rev = None
-    hashes = IndexdField({})
-    acl = IndexdField([])
+    hashes = {}
+    acl = []
     # The metadata property is already used by sqlalchemy
-    _metadata = IndexdField({})
-    size = IndexdField(None)
+    _metadata = {}
+    size = None
 
     @reconstructor
+    def constructor(self):
+        """
+        Builds the object by initializing properties and updating them
+        from indexd.
+
+        """
+        # Fields used by indexd, but not tracked in the database
+        self.file_name = ''
+        self.urls = []
+        self.rev = None
+        self.hashes = {}
+        self.acl = []
+        # The metadata property is already used by sqlalchemy
+        self._metadata = {}
+        self.size = None
+        # Update fields from indexd
+        self.merge_indexd()
+
     def merge_indexd(self):
         """
-        Gets additional fields from indexd
-
         If the document matching this object's latest_did cannot be found in
         indexd, remove the object from the database
 

--- a/dataservice/api/genomic_file/resources.py
+++ b/dataservice/api/genomic_file/resources.py
@@ -1,3 +1,4 @@
+import datetime
 from flask import abort, request
 from marshmallow import ValidationError
 from sqlalchemy.orm import joinedload
@@ -138,6 +139,11 @@ class GenomicFileAPI(CRUDView):
         except ValidationError as err:
             abort(400,
                   'could not update genomic_file: {}'.format(err.messages))
+
+        # The object won't be updated if only indexd fields are updated.
+        # Explicitly update the one of the mapped fields to force an update
+        # to the database.
+        gf.modified_at = datetime.datetime.now()
 
         db.session.add(gf)
         db.session.commit()

--- a/dataservice/api/study_file/resources.py
+++ b/dataservice/api/study_file/resources.py
@@ -1,3 +1,4 @@
+import datetime
 from flask import abort, request
 from marshmallow import ValidationError
 from webargs.flaskparser import use_args
@@ -116,6 +117,11 @@ class StudyFileAPI(CRUDView):
                                                     partial=True).data)
         except ValidationError as err:
             abort(400, 'could not update study_file: {}'.format(err.messages))
+
+        # The object won't be updated if only indexd fields are updated.
+        # Explicitly update the one of the mapped fields to force an update
+        # to the database.
+        st.modified_at = datetime.datetime.now()
 
         db.session.add(st)
         db.session.commit()

--- a/tests/genomic_file/test_genomic_file_models.py
+++ b/tests/genomic_file/test_genomic_file_models.py
@@ -1,3 +1,4 @@
+import datetime
 import uuid
 import random
 import pytest
@@ -190,6 +191,8 @@ class ModelTest(IndexdTestCase):
         gf = GenomicFile.query.get(kwargs['kf_id'])
         gf.acl = ['INTERNAL', 'new_acl']
         did = gf.latest_did
+        # explicitly tell the object to update one of the mapped fields
+        gf.modified_at = datetime.datetime.now()
         db.session.commit()
 
         # Check database

--- a/tests/study_file/test_study_file_models.py
+++ b/tests/study_file/test_study_file_models.py
@@ -1,3 +1,4 @@
+import datetime
 from sqlalchemy.exc import IntegrityError
 
 from dataservice.extensions import db
@@ -72,6 +73,7 @@ class ModelTest(IndexdTestCase):
         sf.hashes = {'md5': 'dcff06ebb19bc9aa8f1aae1288d10dc2'}
         # Update to a new acl
         sf.acl = ['new_acl']
+        sf.modified_at = datetime.datetime.now()
         did = sf.latest_did
         db.session.add(sf)
         db.session.commit()
@@ -99,6 +101,7 @@ class ModelTest(IndexdTestCase):
         # New content values
         sf.size = 1234
         sf.hashes = {'md5': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'}
+        sf.modified_at = datetime.datetime.now()
         did = sf.latest_did
         db.session.add(sf)
         db.session.commit()


### PR DESCRIPTION
Reverts to relying on changes to one of the mapped fields to issue `UPDATE` statements to postgres and thus triggering the `update` event.