### PR TITLE
🐛 Allow independent updates for size and hashes

### DIFF
--- a/dataservice/extensions/flask_indexd.py
+++ b/dataservice/extensions/flask_indexd.py
@@ -161,9 +161,9 @@ class Indexd(object):
             "metadata": record._metadata
         }
 
-        if req_body['size'] == old['size']:
+        if (req_body['size'] == old['size'] and
+           req_body['hashes'] == old['hashes']):
             del req_body['size']
-        if req_body['hashes'] == old['hashes']:
             del req_body['hashes']
 
         # If acl changed, update all previous version with new acl

--- a/tests/genomic_file/test_genomic_file_models.py
+++ b/tests/genomic_file/test_genomic_file_models.py
@@ -126,7 +126,7 @@ class ModelTest(IndexdTestCase):
         Test update genomic file
         """
         # Create and save genomic files and dependent entities
-        biospecimen_id, kwargs_dict = self._create_save_genomic_files()
+        _, kwargs_dict = self._create_save_genomic_files()
 
         # Update fields
         kwargs = kwargs_dict[list(kwargs_dict.keys())[0]]
@@ -142,13 +142,12 @@ class ModelTest(IndexdTestCase):
         [self.assertEqual(getattr(gf, k), v)
          for k, v in kwargs.items()]
 
-
     def test_update_indexd_only(self):
         """
         Test updating of only indexd fields
         """
         # Create and save genomic files and dependent entities
-        biospecimen_id, kwargs_dict = self._create_save_genomic_files()
+        _, kwargs_dict = self._create_save_genomic_files()
 
         kwargs = kwargs_dict[list(kwargs_dict.keys())[1]]
 
@@ -167,20 +166,18 @@ class ModelTest(IndexdTestCase):
 
         assert self.indexd.Session().post.call_count == 3
 
-        expected = {
-            'file_name': 'hg38.bam',
-            'form': 'object',
+        expected = MockIndexd.doc_base.copy()
+        expected.update({
             'size': 1234,
             'acl': ["new_acl"],
-            'urls': ['s3://bucket/key'],
-            'metadata': {'test': 'test'}
-        }
+            'metadata': {'test': 'test'},
+        })
         self.indexd.Session().post.assert_any_call(
                 '{}?rev={}'.format(did, gf.rev), json=expected)
 
     def test_update_acl_only(self):
         """
-        Test updating of only acl field 
+        Test updating of only acl field
         """
         # Create and save genomic files and dependent entities
         biospecimen_id, kwargs_dict = self._create_save_genomic_files()

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -32,26 +32,30 @@ class MockIndexd(MagicMock):
     - GET - get info on a document or version by did
     """
 
-    doc = {
-        "baseid": "dc51eafd-1a7a-48ea-8800-3dfef5f9bd49",
-        "created_date": "2018-02-21T00:44:27.414661",
-        "did": "",
+    doc_base = {
         "file_name": "hg38.bam",
         "form": "object",
         "hashes": {
             "md5": "dcff06ebb19bc9aa8f1aae1288d10dc2"
         },
+        "size": 7696048,
+        "urls": [
+            "s3://bucket/key"
+        ],
+    }
+
+    doc = doc_base.copy()
+    doc.update({
+        "baseid": "dc51eafd-1a7a-48ea-8800-3dfef5f9bd49",
+        "created_date": "2018-02-21T00:44:27.414661",
+        "did": "",
         "metadata": {
         },
         "acl": ["INTERNAL"],
         "rev": "39b19b2d",
-        "size": 7696048,
         "updated_date": "2018-02-21T00:44:27.414671",
-        "urls": [
-            "s3://bucket/key"
-        ],
         "version": None
-    }
+    })
 
     # Need to store docs so new docs vs new versions can be differentiated
     baseid_by_did = {}
@@ -59,7 +63,6 @@ class MockIndexd(MagicMock):
     def __init__(self, *args, status_code=200, **kwargs):
         super(MockIndexd, self).__init__(*args, **kwargs)
         self.status_code = status_code
-
 
     def post(self, url, *args, **kwargs):
         """


### PR DESCRIPTION
Shouldn't be an issue seeing as size and hashes must be changed together, but otherwise will throw 500, so this is more freindly.