### PR TITLE
🔧 Increase nginx proxy_buffer size to stop truncating repsonses

### DIFF
--- a/bin/nginx.conf
+++ b/bin/nginx.conf
@@ -32,6 +32,8 @@ http {
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
+      proxy_buffers 8 32k;
+      proxy_buffer_size 4k;
       proxy_redirect off;
       proxy_pass http://gunicorn_server;
     }


### PR DESCRIPTION
Fixes issues with nginx truncating large responses.