### PR TITLE
⚡️ Indexd bulk fetching

### DIFF
--- a/dataservice/extensions/flask_indexd.py
+++ b/dataservice/extensions/flask_indexd.py
@@ -33,7 +33,8 @@ class Indexd(object):
         s = requests.Session()
         s.auth = (current_app.config['INDEXD_USER'],
                   current_app.config['INDEXD_PASS'])
-        s.headers.update({'Content-Type': 'application/json'})
+        s.headers.update({'Content-Type': 'application/json',
+                          'User-Agent': 'Kids First Dataservice'})
         return s
 
     def teardown(self, exception):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -66,7 +66,7 @@ class MockIndexd(MagicMock):
 
     def post(self, url, *args, **kwargs):
         """
-        Mocks a response from POST /index/
+        Mocks a response from POST /index/ and POST /bulk/documents
         """
 
         resp = {
@@ -82,6 +82,9 @@ class MockIndexd(MagicMock):
         else:
             # Otherwise, assume creation of a new doc and track the baseid
             self.baseid_by_did[resp['did']] = resp['baseid']
+
+        if 'bulk/documents' in url:
+            resp = [resp]
 
         mock_resp = MockResp(resp=resp, status_code=self.status_code)
         return mock_resp


### PR DESCRIPTION
## Need to release latest gen3 into production before release.

Using local indexd
Single request per entity in result
```
Getting 15719 results from /genomic-files in size of 100
Expected requests: 157
150/157
Total Requests: 158
Total Elapsed time: 232.80341982841492
Average Resp time: 1.4707968987341766
```

Using page prefetching
```
Getting 15719 results from /genomic-files in size of 100
Expected requests: 157
150/157
Total Requests: 158
Total Elapsed time: 32.46433401107788
Average Resp time: 0.2029419873417721
```

Fixes #442