### PR TITLE
🔥 Remove cascade delete genomic file on sequencing-experiment delete

### DIFF
--- a/dataservice/api/sequencing_experiment/models.py
+++ b/dataservice/api/sequencing_experiment/models.py
@@ -63,7 +63,6 @@ class SequencingExperiment(db.Model, Base):
     mean_read_length = db.Column(db.Float(),
                                  doc='Mean lenth of the reads')
     genomic_files = db.relationship(GenomicFile,
-                                    cascade="all, delete-orphan",
                                     backref=db.backref(
                                         'sequencing_experiment',
                                         lazy=True))


### PR DESCRIPTION
When a sequencing experiment is deleted, its associated genomic files will not be deleted.