### PR TITLE
🐛 Fix down rev in migration

### DIFF
--- a/migrations/versions/c89c99674f2c_.py
+++ b/migrations/versions/c89c99674f2c_.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'c89c99674f2c'
-down_revision = '7f0b46d388a1'
+down_revision = 'd107dfcba1c1'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Wrong down revision in migration script was previously committed. Fixes the rev by setting down rev to the latest migration revision