### PR TITLE
🎨 Make capitalization consistent for resources

### DIFF
--- a/dataservice/api/docs/resources.py
+++ b/dataservice/api/docs/resources.py
@@ -40,9 +40,10 @@ class Swagger(View):
 
         tags = []
         for d in glob.glob('dataservice/api/*/README.md'):
-            name = d.split('/')[-2].capitalize()
+            name = d.split('/')[-2].replace('_', ' ')
+            name = name.title().replace(' ', '')
             tag = {
-                'name': name.capitalize(),
+                'name': name,
                 'description': open(d, 'r').read()
             }
             tags.append(tag)

--- a/dataservice/api/templates/delete_by_id.yml
+++ b/dataservice/api/templates/delete_by_id.yml
@@ -4,7 +4,7 @@ tags:
 parameters:
 - name: kf_id
   in: path
-  description: "ID of {{ resource.lower() }} to return"
+  description: "ID of {{ resource }} to return"
   required: true
   type: string
 responses:

--- a/dataservice/api/templates/get_by_id.yml
+++ b/dataservice/api/templates/get_by_id.yml
@@ -4,7 +4,7 @@ tags:
 parameters:
 - name: "kf_id"
   in: "path"
-  description: "ID of {{ resource.lower() }} to return"
+  description: "ID of {{ resource }} to return"
   required: true
   type: "string"
 responses:

--- a/dataservice/api/templates/get_list.yml
+++ b/dataservice/api/templates/get_list.yml
@@ -1,4 +1,4 @@
-description: Get {{ resource.lower() }}s
+description: Get {{ resource }}s
 tags:
 - {{ resource }}
 responses:

--- a/dataservice/api/templates/update_by_id.yml
+++ b/dataservice/api/templates/update_by_id.yml
@@ -1,10 +1,10 @@
-description: Partial update of a {{ resource.lower() }}
+description: Partial update of a {{ resource }}
 tags:
 - {{ resource }}
 parameters:
 - name: kf_id
   in: path
-  description: ID of the {{ resource.lower() }}to return
+  description: ID of the {{ resource }}to return
   required: true
   type: string
 - name: body


### PR DESCRIPTION
The swagger docs had inconsistencies where readme directories were not formatted to be equivalent to actual resources, resulting in two categories for some resources, eg: `GENOMICFILE` and `GENOMIC_FILE`.

Some of the templates were using `resource.lower()` where others just used `resource` making some endpoint inconsistent, eg `Get a GenomicFile` vs `Delete a genomicfile`