### PR TITLE
✨ Summarize sequencing experiment fields on genomic file

### DIFF
--- a/dataservice/api/genomic_file/schemas.py
+++ b/dataservice/api/genomic_file/schemas.py
@@ -58,6 +58,10 @@ class GenomicFileSchema(BaseSchema, IndexdFileSchema):
     sequencing_experiment_id = field_for(GenomicFile,
                                          'sequencing_experiment_id',
                                          load_only=True)
+    experiment_strategies = fields.List(fields.Str(), dump_only=True)
+    platforms = fields.List(fields.Str(), dump_only=True)
+    instrument_models = fields.List(fields.Str(), dump_only=True)
+    is_paired_end = fields.Bool(dump_only=True)
 
     latest_did = field_for(GenomicFile,
                            'latest_did',

--- a/tests/genomic_file/test_genomic_file_resources.py
+++ b/tests/genomic_file/test_genomic_file_resources.py
@@ -87,11 +87,38 @@ def test_new(client, indexd, entities):
     assert 'genomic_file' in resp['_status']['message']
     assert 'created' in resp['_status']['message']
     assert resp['results']['file_name'] == 'hg38.bam'
+    assert resp['results']['experiment_strategies'] == ['WXS']
+    assert resp['results']['platforms'] == ['Illumina']
+    assert resp['results']['instrument_models'] == ['HiSeq']
 
     genomic_file = resp['results']
     gf = GenomicFile.query.get(genomic_file['kf_id'])
     assert gf
     assert indexd.post.call_count == orig_calls + 1
+
+
+def test_no_hybrid_posts(client, indexd, entities):
+    """
+    Test that hybrid fields cannot be populated
+    """
+    orig_calls = indexd.post.call_count
+    body = {
+        'external_id': 'genomic_file_0',
+        'file_name': 'hg38.bam',
+        'size': 123,
+        'data_type': 'Aligned Reads',
+        'file_format': 'bam',
+        'urls': ['s3://bucket/key'],
+        'hashes': {'md5': 'd418219b883fce3a085b1b7f38b01e37'},
+        'availability': 'Immediate Download',
+        'controlled_access': False,
+        'experiment_strategies': 'WGS',
+    }
+    resp = client.post(url_for(GENOMICFILE_LIST_URL),
+                       headers={'Content-Type': 'application/json'},
+                       data=json.dumps(body))
+
+    assert resp.json['results']['experiment_strategies'] == []
 
 
 def test_new_indexd_error(client, entities):


### PR DESCRIPTION
Reflects `platforms`, `experiment_strategies`, and `platforms` of a sequencing experiment on the genomic file. In the future, these values will also include summary of all upstream file's sequencing experiments so as to allow them to be discovered when one searches for files that are the product of a specific value of them.

Mirrors `is_paired_end` from sequencing experiment onto the genomic file.