### PR TITLE
🔊 Add response timing to logs

### DIFF
--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -25,6 +25,6 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:gunicorn]
-command=gunicorn manage:app -b localhost:5000 --workers 3
+command=gunicorn manage:app -b localhost:5000 --workers 3 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s' --access-logfile -
 stderr_logfile=/dev/stdout
 stderr_logfile_maxbytes=0


### PR DESCRIPTION
Adds the response time to the logging output in gunicorn so that we may keep an eye on response time from our API and different endpoints.