### PR TITLE
🐳 Remove venv from docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.circleci/
+tests/
+venv/
+data/
+tests/
+dumps/
+pyenv/
+*/__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update && apk add py3-psycopg2 musl-dev \
  && pip install --upgrade pip
 
 RUN         pip install -r /app/requirements.txt
-ADD         . /app
+COPY        dataservice docs .git migrations bin manage.py config.py setup.py /app/
 RUN         python /app/setup.py install
 
 EXPOSE      80

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN apk update && apk add py3-psycopg2 musl-dev \
     nginx supervisor git \
     openssl ca-certificates \
     gcc postgresql-dev \
- && pip install --upgrade pip \
- && pip install virtualenv
+ && pip install --upgrade pip
 
 RUN         pip install -r /app/requirements.txt
 ADD         . /app

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,4 +1,3 @@
 #!/bin/ash
-source venv/bin/activate
 flask db upgrade
 supervisord -c  /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
This removes references to `venv` from the `run.sh` command which seems to only have been working because there was a `venv` in the build directory. I've also added a '.dockeringore' that will prevent these unused resources from being added to the docker build context.