### PR TITLE
🔊 Move log formatting to nginx.conf

### DIFF
--- a/bin/nginx.conf
+++ b/bin/nginx.conf
@@ -9,8 +9,13 @@ events {
 }
 
 http {
+  log_format request_time '$remote_addr - $remote_user [$time_local] '
+                             '"$request" $status $body_bytes_sent '
+                             '"$http_referer" "$http_user_agent" '
+                             '$request_time';
+
   include mime.types;
-  access_log /dev/stdout;
+  access_log /dev/stdout request_time;
   default_type application/octet-stream;
 
   client_body_temp_path /tmp 1 2;

--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -25,6 +25,6 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:gunicorn]
-command=gunicorn manage:app -b localhost:5000 --workers 3 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s' --access-logfile -
+command=gunicorn manage:app -b localhost:5000 --workers 3
 stderr_logfile=/dev/stdout
 stderr_logfile_maxbytes=0


### PR DESCRIPTION
This removes the gunicorn logging config set in #514 and adds it to the nginx logs as gunicorn logs aren't the actual logs being sent to stdout in a production container.