### PR TITLE
🐛 Individually copy files to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN         pip install -r /app/requirements.txt
 
 COPY        manage.py manage.py
 COPY        setup.py setup.py
+COPY        config.py config.py
 COPY        bin bin
 COPY        docs docs
 COPY        migrations migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,15 @@ RUN apk update && apk add py3-psycopg2 musl-dev \
  && pip install --upgrade pip
 
 RUN         pip install -r /app/requirements.txt
-COPY        dataservice docs .git migrations bin manage.py config.py setup.py /app/
+
+COPY        manage.py manage.py
+COPY        setup.py setup.py
+COPY        bin bin
+COPY        docs docs
+COPY        migrations migrations
+COPY        dataservice  dataservice
+COPY        .git .git
+
 RUN         python /app/setup.py install
 
 EXPOSE      80


### PR DESCRIPTION
`COPY dir1/ dir2/ /app/` only copies the contents of the directories to the image, not the actual directories themselves.