### PR TITLE
🏷 Release 1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# Kids First Dataservice Release 1.10.4
+
+## Features
+
+Fixes issue with pagination potentially skipping entries with similiar creation
+dates.
+
+### Summary
+
+Feature Emojis: ✨x1
+Feature Labels: [bug](https://api.github.com/repos/kids-first/kf-api-dataservice/labels/bug) x1 [feature](https://api.github.com/repos/kids-first/kf-api-dataservice/labels/feature) x1 [refactor](https://api.github.com/repos/kids-first/kf-api-dataservice/labels/refactor) x1
+
+### New features and changes
+
+- (#529) ✨ Add pagination by uuid - @dankolbman
+
+
 # Kids First Dataservice Release 1.10.3
 
 ## Features

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="kf-api-dataservice",
-    version="1.10.3",
+    version="1.10.4",
     description="Data Service API",
     license="Apache 2",
     packages=find_packages()


### PR DESCRIPTION
# Kids First Dataservice Release 1.10.4

## Features

Fixes issue with pagination potentially skipping entries with similar creation
dates.

### Summary

Feature Emojis: ✨x1
Feature Labels: [bug](https://api.github.com/repos/kids-first/kf-api-dataservice/labels/bug) x1 [feature](https://api.github.com/repos/kids-first/kf-api-dataservice/labels/feature) x1 [refactor](https://api.github.com/repos/kids-first/kf-api-dataservice/labels/refactor) x1

### New features and changes

- (#529) ✨ Add pagination by uuid - @dankolbman