### PR TITLE
👷 Add agent label to jenkins config for Terraform Upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
 @Library(value='kids-first/aws-infra-jenkins-shared-libraries', changelog=false) _
+
 ecs_service_type_1 {
     projectName = "kf-api-dataservice"
+    agentLabel = "terraform-testing"
 }


### PR DESCRIPTION
This is to build on the jenkins node that has the new terraform version.