### PR TITLE
✨ Add Indexd authz field

### DIFF
--- a/dataservice/api/common/model.py
+++ b/dataservice/api/common/model.py
@@ -82,6 +82,7 @@ class IndexdFile:
     rev = None
     hashes = {}
     acl = []
+    authz = []
     # The metadata property is already used by sqlalchemy
     _metadata = {}
     size = None
@@ -99,6 +100,7 @@ class IndexdFile:
         self.rev = None
         self.hashes = {}
         self.acl = []
+        self.authz = []
         # The metadata property is already used by sqlalchemy
         self._metadata = {}
         self.size = None

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -111,10 +111,19 @@ class BaseSchema(ma.ModelSchema):
             raise ValidationError('Unknown field', unknown)
 
 
+def acl_deprecation(v):
+    if v is not None and not v == []:
+        raise ValidationError(
+            "The ACL field has been disabled. Use the authz field instead."
+        )
+
+
 class IndexdFileSchema(Schema):
     urls = ma.List(ma.Str(), required=True)
     access_urls = ma.List(ma.Str(), dump_only=True)
-    acl = ma.List(ma.Str(), required=False)
+    acl = ma.List(
+        ma.Str(), required=False, validate=lambda v: acl_deprecation(v)
+    )
     authz = ma.List(ma.Str(), required=False)
     file_name = ma.Str()
     hashes = ma.Dict(required=True)

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -115,6 +115,7 @@ class IndexdFileSchema(Schema):
     urls = ma.List(ma.Str(), required=True)
     access_urls = ma.List(ma.Str(), dump_only=True)
     acl = ma.List(ma.Str(), required=False)
+    authz = ma.List(ma.Str(), required=False)
     file_name = ma.Str()
     hashes = ma.Dict(required=True)
     metadata = ma.Dict(attribute='_metadata')

--- a/tests/genomic_file/test_genomic_file_resources.py
+++ b/tests/genomic_file/test_genomic_file_resources.py
@@ -103,6 +103,7 @@ def test_new_indexd_error(client, entities):
         'file_name': 'hg38.bam',
         'size': 123,
         'acl': ['TEST'],
+        'authz': ['/projects/TEST'],
         'data_type': 'Aligned Reads',
         'file_format': 'bam',
         'urls': ['s3://bucket/key'],
@@ -183,6 +184,7 @@ def test_get_one(client, entities):
     assert 'rev' not in resp
     assert resp['size'] == gf.size
     assert resp['acl'] == gf.acl
+    assert resp['authz'] == gf.authz
     # check properties from datamodel
     assert resp['file_name'] == gf.file_name
     assert resp['data_type'] == gf.data_type

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -51,7 +51,8 @@ class MockIndexd(MagicMock):
         "did": "",
         "metadata": {
         },
-        "acl": ["INTERNAL"],
+        "acl": [],
+        "authz": ["/programs/INTERNAL"],
         "rev": "39b19b2d",
         "updated_date": "2018-02-21T00:44:27.414671",
         "version": None

--- a/tests/study_file/test_study_file_models.py
+++ b/tests/study_file/test_study_file_models.py
@@ -60,7 +60,8 @@ class ModelTest(IndexdTestCase):
 
     def test_update_all_versions(self):
         """
-        Test that all verions of a document are updated when the acl is changed
+        Test that all verions of a document are updated when the autz is
+        changed
         """
         # Create study_files and study
         study_files, study, data = self.create_study_file()
@@ -72,7 +73,8 @@ class ModelTest(IndexdTestCase):
         sf.size = 7696048
         sf.hashes = {'md5': 'dcff06ebb19bc9aa8f1aae1288d10dc2'}
         # Update to a new acl
-        sf.acl = ['new_acl']
+        sf.acl = []
+        sf.authz = ['/programs/new-authz']
         sf.modified_at = datetime.datetime.now()
         did = sf.latest_did
         db.session.add(sf)
@@ -97,7 +99,7 @@ class ModelTest(IndexdTestCase):
 
         sf = StudyFile.query.get(study_files[0].kf_id)
         # Set to value returned in the mock endpoint
-        sf.acl = ['INTERNAL']
+        sf.authz = ['/programs/INTERNAL']
         # New content values
         sf.size = 1234
         sf.hashes = {'md5': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'}


### PR DESCRIPTION
## About

The `acl` field is being replaced with a new `authz` field which will correspond to policies created in [Arborist](https://github.com/uc-cdis/arborist). These policies will be created automatically according to our `users.yml` and `dbGaP` syncing, so we will not have to worry about creating them. There is no validation on them, either, so we can populate them regardless of whether they reference legitimate policies or not.

Moving fhe `acl` field is intended to be used as a fallback if a record has no `authz` field.
Because access is currently determined by the consuming application, it is possible that we may have a divergence in some services that continue to check the `acl` field even after the `authz` field has been added. Therefore, we should manage the `acl` as conservatively as possible. Locking down the `acl` to remain empty is by far the safest solution.

## Migrating

Gen3 Indexd has a migration script that will populate `authz` fields based on the `acl` field. This script will be run to update everything to `authz` policies.
After this has occurred, we will be able to manually set all record's `acl` to be empty to ensure that it is not used when determining access to the record.

## Features

### New `authz` Field

Adds a pass-through `authz` field for Indexd documents similar to other fields that are relayed through dataservice to/from indexd.
This field is not persisted inside of the dataservice, but proxied to and from Indexd where it is stored.

### Disable `acl` Field for Records

An error will be returned when a record is created or update with a new or non-empty `acl` field.
This will force any new data to be created using the new `authz` field instead of using the soon to be deprecated `acl` field.

```
$ curl -s -XPOST localhost:5000/genomic-files -d '{"acl": ["abc", "123"], "urls": ["s3://abc/abc"], "hashes": {"md5":"e4b246e5bac1f152b3b13047a4876b84"}, "size": 10}' | jq
{
  "_status": {
    "code": 400,
    "message": "could not create genomic_file: {'acl': ['The ACL field has been disabled. Use the authz field instead.']}"
  }
}
```

**NB: This will deprecate creating/updating the acl field and fail requests that specify one. Updates to existing documents that do not wish to change the acl should remove it from the body.**

Fixes  #536 