### PR TITLE
⬆️ Bump pytest to 5.2.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 codacy-coverage==1.3.10
-pytest==3.3.1
+pytest==5.2.0
 pytest-cache==1.0
 pytest-cov==2.5.1
 pytest-pep8==1.0.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,10 @@ def swagger(client):
 
 @pytest.fixture(scope='module')
 def entities(client):
+    return make_entities(client)
+
+
+def make_entities(client):
     # Create initial entities
     with db.session.no_autoflush:
         _entities = defaultdict(list)

--- a/tests/genomic_file/test_genomic_file_resources.py
+++ b/tests/genomic_file/test_genomic_file_resources.py
@@ -14,7 +14,7 @@ from dataservice.api.sequencing_center.models import SequencingCenter
 from dataservice.api.read_group.models import ReadGroup
 from dataservice.api.sequencing_experiment.models import SequencingExperiment
 from dataservice.api.genomic_file.models import GenomicFile
-from tests.conftest import entities as ent
+from tests.conftest import make_entities
 from tests.conftest import ENTITY_TOTAL
 from tests.mocks import MockIndexd
 
@@ -26,7 +26,7 @@ EXPECTED_TOTAL = ENTITY_TOTAL + 102 * 2
 
 @pytest.fixture(scope='function')
 def entities(client):
-    return ent(client)
+    return make_entities(client)
 
 
 @pytest.yield_fixture(scope='function')

--- a/tests/study_file/test_study_file_resources.py
+++ b/tests/study_file/test_study_file_resources.py
@@ -10,7 +10,7 @@ from dataservice.extensions import db
 from dataservice.api.study_file.models import StudyFile
 from dataservice.api.study.models import Study
 from tests.utils import FlaskTestCase
-from tests.conftest import entities as ent
+from tests.conftest import make_entities
 from tests.conftest import ENTITY_TOTAL
 from unittest.mock import MagicMock, patch
 from tests.mocks import MockIndexd
@@ -22,7 +22,7 @@ EXPECTED_TOTAL = ENTITY_TOTAL + 102
 
 @pytest.fixture(scope='function')
 def entities(client):
-    return ent(client)
+    return make_entities(client)
 
 
 @pytest.yield_fixture(scope='function')
@@ -161,7 +161,7 @@ def test_get_list_with_missing_files(client, indexd, study_files):
     for res in resp['results']:
         assert 'kf_id' in res
     expected = EXPECTED_TOTAL
-    assert indexd.get.call_count == expected 
+    assert indexd.get.call_count == expected
 
 
 def test_get_one(client, entities):


### PR DESCRIPTION
CircleCI is failing: 
![image](https://user-images.githubusercontent.com/10283712/67305864-12577680-f4c4-11e9-9d14-f4800209bf52.png)

**Notes**

- Upgrading to this version of pytest solves the problem. See details on issue on SO here: 
https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert

- As a result we need to change some test code bc pytest 5.2 deprecated the feature where you can call fixtures directly. See https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly