### PR TITLE
🐳 Publish port for postgres database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: postgres:11.1
     environment:
       POSTGRES_DB: "dataservice"
+    ports:
+        - "5432:5432"
   dataservice:
     build: .
     command: /bin/ash -c "sleep 5; ./bin/run.sh"


### PR DESCRIPTION
The Docker Compose doesn't automatically make the psql database available locally. This forwards the container's port to localhost:5432