### PR TITLE
📌 Pin PyYAML to avoid apispec breaking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ boto3==1.7.8
 botocore==1.10.8
 Jinja2==2.10
 requests==2.24.0
+PyYAML==5.4


### PR DESCRIPTION
The API is breaking at runtime because PyYAML, a dependency of the library apispec, was not pinned and the resulting PyYAML distribution that gets installed has a breaking change. We need to pin PyYAML so that this doesn't happen.