### PR TITLE
⚗️ Check Docker python image

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 
+
 setup(
     name="kf-api-dataservice",
     version="1.11.0",


### PR DESCRIPTION
I can't build the dataservice docker image. Changing `python:3-alpine3.7` in `Dockerfile` to `python:3.7-alpine` made it work. This is a test to see if jenkins will build the image with the seemingly outdated python image.