### PR TITLE
🔥 remove polya_stranded library_prep

### DIFF
--- a/dataservice/api/sequencing_experiment/schemas.py
+++ b/dataservice/api/sequencing_experiment/schemas.py
@@ -26,7 +26,7 @@ LIBRARY_SELECTION_ENUM = {'Hybrid Selection', 'PCR', 'Affinity Enrichment',
                           'Poly-T Enrichment', 'Random', 'rRNA Depletion',
                           'miRNA Size Fractionation', 'Other'}
 
-LIBRARY_PREP_ENUM = {'polyA', 'polyA Stranded', 'totalRNAseq', 'Other'}
+LIBRARY_PREP_ENUM = {'polyA', 'totalRNAseq', 'Other'}
 
 
 class SequencingExperimentSchema(BaseSchema):


### PR DESCRIPTION
we have columns in the ds for library_prep and for stranded-ness. having a library prep enum for polya_stranded combines these two columns when we want to keep them seperated.