### PR TITLE
:arrow_up: Upgrade to latest psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ gunicorn==19.7.1
 flask-marshmallow==0.8.0
 marshmallow==2.16.0
 marshmallow-sqlalchemy==0.13.2
-psycopg2==2.7.3.2
+psycopg2==2.9.6
 webargs==5.3.0
 boto3==1.7.8
 botocore==1.10.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==0.9.6
 aniso8601==1.3.0
 apispec==0.29.0
-click==6.6
+click==7.1.2
 Flask==1.0.2
 Flask-Migrate==2.1.1
 Flask-Profile==0.2


### PR DESCRIPTION
Part of #612 

- Upgrading to the latest version. Doesn't appear to have breaking changes per [release notes](https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-9)
- Current version 2.7.3.2 seems to have issues installing on OSX Ventura (and maybe other newer versions of OSX?)
- Current version is extremely old (from 2015)