### PR TITLE
:sparkles: Add Saliva Kit to SAMPLE_PROCUREMENT_ENUM for Letra

### DIFF
--- a/dataservice/api/biospecimen/schemas.py
+++ b/dataservice/api/biospecimen/schemas.py
@@ -26,6 +26,10 @@ SAMPLE_PROCUREMENT_ENUM = {
     "Saliva Collection - Proband",
     "Blood Collection - Maternal", "Saliva Collection - Maternal",
     "Blood Collection - Paternal", "Saliva Collection - Paternal",
+    # general Saliva Kit (as with Letra's extended multiplex families):
+    "Saliva Kit",
+    # NOTE: SAMPLE_PROCUREMENT.SALIVA_KIT was already added to the ingest lib,
+    # hence "Saliva Kit" as the general variation to "Saliva Collection - *"
 }
 # Codes from http://purl.obolibrary.org/obo/duo.owl
 DUO_ID_BIOSPECIMEN_ENUM = {


### PR DESCRIPTION
✨ Add new Saliva Kit for sample procurement enum,

Note that `SAMPLE_PROCUREMENT.SALIVA_KIT` had already been added to the ingest lib (as at https://github.com/kids-first/kf-lib-data-ingest/pull/657), hence the use of "_Saliva Kit_" as the general variation to the following:
*  _"Saliva Collection - Proband"_
*  _"Saliva Collection - Maternal"_
*  _"Saliva Collection - Paternal"_

