### PR TITLE
:busts_in_silhouette: Add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+*              @kids-first/dataservice-reviewers
+/.github/      @kids-first/dataservice-reviewers @kids-first/devops
+/.circleci/    @kids-first/dataservice-reviewers @kids-first/devops
+/.dockerignore @kids-first/dataservice-reviewers @kids-first/devops
+/Dockerfile    @kids-first/dataservice-reviewers @kids-first/devops
+/Jenkinsfile   @kids-first/dataservice-reviewers @kids-first/devops


### PR DESCRIPTION
- Add a codeowners file so that we can ensure at least 1 review and approval from engineers that are familiar with the code base before merging into master branch
- This will also help us be more cautious in deploying the QA service (happens when PRs merge into master). Caution is important here since QA is often used to test long running ETLs thus requiring coordination among teams