### PR TITLE
✨ Store ACL in new authz field

### DIFF
--- a/dataservice/api/common/model.py
+++ b/dataservice/api/common/model.py
@@ -86,7 +86,11 @@ class IndexdFile:
     urls = []
     rev = None
     hashes = {}
+    # acl is DEPRECATED - But keeping this for now for debugging and migration
+    # purposes
     acl = []
+    # The new field to capture access control lists instead of acl
+    authz = []
     # The metadata property is already used by sqlalchemy
     _metadata = {}
     size = None
@@ -104,6 +108,7 @@ class IndexdFile:
         self.rev = None
         self.hashes = {}
         self.acl = []
+        self.authz = []
         # The metadata property is already used by sqlalchemy
         self._metadata = {}
         self.size = None

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -123,16 +123,17 @@ class BaseSchema(ma.ModelSchema):
 
 def acl_deprecation(val):
     """
-    Ensure that user is not populating the ACL field. ACL field can only be an 
+    Ensure that user is not populating the ACL field. ACL field can only be an
     empty list
 
     If ACL field is not a list, this will be caught marshmallow type validation
-    Therefore, only check if ACL field contains a non-empty list and raise 
+    Therefore, only check if ACL field contains a non-empty list and raise
     an exception if it is not
     """
     if isinstance(val, list) and len(val) > 0:
         raise ValidationError(
-            "The ACL field has been deprecated. Please use the authz field instead"
+            "The ACL field has been deprecated. "
+            "Please use the authz field instead"
         )
 
 

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -121,10 +121,21 @@ class BaseSchema(ma.ModelSchema):
             raise ValidationError('Unknown field', unknown)
 
 
+def acl_deprecation(val):
+    """
+    Ensure that user is not populating the ACL field
+    """
+    if isinstance(val, list) and len(val) > 0:
+        raise ValidationError(
+            "The ACL field has been deprecated. Please use the authz field instead"
+        )
+
+
 class IndexdFileSchema(Schema):
     urls = ma.List(ma.Str(), required=True)
     access_urls = ma.List(ma.Str(), dump_only=True)
-    acl = ma.List(ma.Str(), required=False)
+    acl = ma.List(ma.Str(), required=False, validate=acl_deprecation)
+    authz = ma.List(ma.Str(), required=False)
     file_name = ma.Str()
     hashes = ma.Dict(required=True)
     metadata = ma.Dict(attribute='_metadata')

--- a/dataservice/api/common/schemas.py
+++ b/dataservice/api/common/schemas.py
@@ -123,7 +123,12 @@ class BaseSchema(ma.ModelSchema):
 
 def acl_deprecation(val):
     """
-    Ensure that user is not populating the ACL field
+    Ensure that user is not populating the ACL field. ACL field can only be an 
+    empty list
+
+    If ACL field is not a list, this will be caught marshmallow type validation
+    Therefore, only check if ACL field contains a non-empty list and raise 
+    an exception if it is not
     """
     if isinstance(val, list) and len(val) > 0:
         raise ValidationError(

--- a/dataservice/api/genomic_file/README.md
+++ b/dataservice/api/genomic_file/README.md
@@ -1,0 +1,8 @@
+**IMPORTANT NOTES**
+
+The `acl field is DEPRECATED` and only exists for data migration purposes. 
+
+Existing genomic files with an acl value can be updated. However, users 
+will NOT be able to create new genomic files with a populated acl field.
+
+The **authz** field should be used instead.

--- a/dataservice/extensions/flask_indexd.py
+++ b/dataservice/extensions/flask_indexd.py
@@ -182,7 +182,7 @@ class Indexd(object):
 
         # If acl changed, update all previous version with new acl
         if record.acl != old['acl']:
-            self._update_all_acls(record)
+            self._update_all_acls(record, key="acl")
 
         # If authz changed, update all previous version with new authz
         if record.authz != old['authz']:
@@ -204,10 +204,18 @@ class Indexd(object):
 
         return record
 
-    def _update_all_acls(self, record, key="acl"):
+    def _update_all_acls(self, record, key="authz"):
         """
-        Update acls for all previous versions of a record and update the
+        Update ACL values for all previous versions of a record and update the
         target record's rev
+
+        Since the GenomicFile.acl field is being deprecated in favor of the
+        new GenomicFile.authz field, the default behavior of this method will
+        be to update the ACL values in the authz field
+
+        Until the GenomicFile.acl field is completely removed from the code
+        base and all GenomicFile.acl values in the DB are migrated into the
+        GenomicFile.authz field, this method will be used to update both fields
         """
         # Only use fields allowed by the indexd PUT schema
         fields = ['urls', 'acl', 'authz', 'file_name', 'version',

--- a/dataservice/extensions/flask_indexd.py
+++ b/dataservice/extensions/flask_indexd.py
@@ -78,6 +78,7 @@ class Indexd(object):
           {
             "file_name": "my_file",
             "acl": ["phs000000"],
+            "authz": ["/programs/phs000000"],
             "hashes": {
               "md5": "0b7940593044dff8e74380476b2b27a9"
             },
@@ -116,6 +117,7 @@ class Indexd(object):
             "form": "object",
             "hashes": record.hashes,
             "acl": record.acl,
+            "authz": record.authz,
             "urls": record.urls,
             "metadata": meta
         }
@@ -168,6 +170,7 @@ class Indexd(object):
             "size": record.size,
             "hashes": record.hashes,
             "acl": record.acl,
+            "authz": record.authz,
             "urls": record.urls,
             "metadata": record._metadata
         }
@@ -180,6 +183,10 @@ class Indexd(object):
         # If acl changed, update all previous version with new acl
         if record.acl != old['acl']:
             self._update_all_acls(record)
+
+        # If authz changed, update all previous version with new authz
+        if record.authz != old['authz']:
+            self._update_all_acls(record, key="authz")
 
         url = '{}{}?rev={}'.format(self.url, record.latest_did, record.rev)
         if 'size' in req_body or 'hashes' in req_body:
@@ -197,22 +204,22 @@ class Indexd(object):
 
         return record
 
-    def _update_all_acls(self, record):
+    def _update_all_acls(self, record, key="acl"):
         """
         Update acls for all previous versions of a record and update the
         target record's rev
         """
         # Only use fields allowed by the indexd PUT schema
-        fields = ['urls', 'acl', 'file_name', 'version',
+        fields = ['urls', 'acl', 'authz', 'file_name', 'version',
                   'metadata', 'urls_metadata', 'rev']
 
         url = '{}{}/versions'.format(self.url, record.latest_did)
         versions = self.session.get(url).json()
         for version, doc in versions.items():
-            if doc['acl'] != record.acl:
+            if doc[key] != getattr(record, key):
                 did = doc['did']
                 doc = {k: v for k, v in doc.items() if k in fields}
-                doc['acl'] = record.acl
+                doc[key] = getattr(record, key)
                 if doc['version'] is None:
                     del doc['version']
                 url = '{}{}?rev={}'.format(self.url, did, doc['rev'])

--- a/tests/genomic_file/test_genomic_file_models.py
+++ b/tests/genomic_file/test_genomic_file_models.py
@@ -109,7 +109,7 @@ class ModelTest(IndexdTestCase):
         gf = GenomicFile.query.get(kwargs['kf_id'])
         gf.external_id = 'blah'
         gf.size = 1234
-        gf.acl = ['new_acl']
+        gf.authz = ['/programs/new_acl']
         gf._metadata = {'test': 'test'}
         did = gf.latest_did
         db.session.commit()
@@ -123,7 +123,8 @@ class ModelTest(IndexdTestCase):
         expected = MockIndexd.doc_base.copy()
         expected.update({
             'size': 1234,
-            'acl': ["new_acl"],
+            'acl': [],
+            'authz': ["/programs/new_acl"],
             'metadata': {'test': 'test'},
         })
         self.indexd.Session().post.assert_any_call(
@@ -140,7 +141,7 @@ class ModelTest(IndexdTestCase):
 
         # Update fields
         gf = GenomicFile.query.get(kwargs['kf_id'])
-        gf.acl = ['INTERNAL', 'new_acl']
+        gf.authz = ['/programs/INTERNAL', '/programs/new_acl']
         did = gf.latest_did
         # explicitly tell the object to update one of the mapped fields
         gf.modified_at = datetime.datetime.now()
@@ -148,14 +149,15 @@ class ModelTest(IndexdTestCase):
 
         # Check database
         gf = GenomicFile.query.get(kwargs['kf_id'])
-        assert gf.acl == ['INTERNAL', 'new_acl']
+        assert gf.authz == ['/programs/INTERNAL', '/programs/new_acl']
 
         # Update document and all versions
         assert self.indexd.Session().put.call_count == 4
 
         expected = {
             'file_name': 'hg38.bam',
-            'acl': ['INTERNAL', 'new_acl'],
+            'acl': [],
+            'authz': ['/programs/INTERNAL', '/programs/new_acl'],
             'urls': ['s3://bucket/key'],
             'metadata': {}
         }

--- a/tests/genomic_file/test_genomic_file_resources.py
+++ b/tests/genomic_file/test_genomic_file_resources.py
@@ -102,7 +102,8 @@ def test_new_validation_error(client, entities):
         'external_id': 'genomic_file_0',
         'file_name': 'hg38.bam',
         'size': 123,
-        'acl': ['TEST'],
+        'acl': [],
+        'authz': ["/programs/TEST"],
         'data_type': 'Aligned Reads',
         'file_format': 'bam',
         'urls': ['s3://bucket/key'],
@@ -122,14 +123,15 @@ def test_new_validation_error(client, entities):
 
 def test_new_indexd_error(client, indexd, entities):
     """
-    Test case when indexd errors
+    Test case when indexd errors. Error is caused by invalid hash algo
     """
     # Invalid hash algo
     body = {
         'external_id': 'genomic_file_0',
         'file_name': 'hg38.bam',
         'size': 123,
-        'acl': ['TEST'],
+        'acl': [],
+        'authz': ["/programs/TEST"],
         'hashes': {"foo": "bar"},
         'data_type': 'Aligned Reads',
         'file_format': 'bam',
@@ -145,6 +147,33 @@ def test_new_indexd_error(client, indexd, entities):
     resp = json.loads(response.data.decode("utf-8"))
     assert 'failed to create new' in resp['_status']['message']
     assert 'indexd create error message' in resp['_status']['message']
+    assert GenomicFile.query.count() == init_count
+
+
+def test_acl_deprecation_on_new(client, entities, genomic_files):
+    """
+    Test that genomic file create fails if deprecated acl field is populated
+    """
+    body = {
+        'external_id': 'genomic_file_0',
+        'file_name': 'hg38.bam',
+        'size': 123,
+        'acl': ['TEST'],
+        'data_type': 'Aligned Reads',
+        'file_format': 'bam',
+        'urls': ['s3://bucket/key'],
+        'controlled_access': False,
+        'hashes': {'md5': 'd418219b883fce3a085b1b7f38b01e37'}
+    }
+    init_count = GenomicFile.query.count()
+    response = client.post(url_for(GENOMICFILE_LIST_URL),
+                           headers={'Content-Type': 'application/json'},
+                           data=json.dumps(body))
+
+    resp = json.loads(response.data.decode("utf-8"))
+
+    assert 400 == response.status_code
+    assert 'ACL field has been deprecated' in resp['_status']['message']
     assert GenomicFile.query.count() == init_count
 
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -60,7 +60,8 @@ class MockIndexd(MagicMock):
         "did": "",
         "metadata": {
         },
-        "acl": ["INTERNAL"],
+        "acl": [],
+        "authz": ["/programs/INTERNAL"],
         "rev": "39b19b2d",
         "updated_date": "2018-02-21T00:44:27.414671",
         "version": None

--- a/tests/study_file/test_study_file_models.py
+++ b/tests/study_file/test_study_file_models.py
@@ -72,7 +72,7 @@ class ModelTest(IndexdTestCase):
         sf.size = 7696048
         sf.hashes = {'md5': 'dcff06ebb19bc9aa8f1aae1288d10dc2'}
         # Update to a new acl
-        sf.acl = ['new_acl']
+        sf.authz = ['new_acl']
         sf.modified_at = datetime.datetime.now()
         did = sf.latest_did
         db.session.add(sf)
@@ -97,7 +97,7 @@ class ModelTest(IndexdTestCase):
 
         sf = StudyFile.query.get(study_files[0].kf_id)
         # Set to value returned in the mock endpoint
-        sf.acl = ['INTERNAL']
+        sf.authz = ['/programs/INTERNAL']
         # New content values
         sf.size = 1234
         sf.hashes = {'md5': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'}
@@ -109,7 +109,6 @@ class ModelTest(IndexdTestCase):
         assert self.indexd.Session().put.call_count == 0
         # Check that no new version was made
         assert self.indexd.Session().post.call_count == orig_post + 1
-
 
     def test_delete(self):
         """


### PR DESCRIPTION
## Motivation

Authorization policy information for indexd files is currently stored in the `acl` list field. However, the `acl` field is being replaced with a new `authz` list field. The values in the `authz` list will correspond to policies created in [Arborist](https://github.com/uc-cdis/arborist). 

Some important things to note:

- If the `authz` field is populated, any values in the `acl` field are ignored
- If the `authz` field is NOT populated, the values in the `acl` field are used as a fallback
- Because of the above two facts, we should manage the deprecated `acl` conservatively by setting it to an empty list (no access) by default

## Approach

#### New `authz` Field

Add an`authz` field for Indexd documents similar to other fields that are relayed through dataservice to/from indexd.
This field is not persisted inside of the dataservice, but proxied to and from Indexd where it is stored.

#### Disable `acl` Field for New Records

An error will be returned when a record is created with a non-empty `acl` field.
This will force any new data to be created using the new `authz` field instead of using the soon to be deprecated `acl` field.

```shell
$ curl -X POST localhost:5000/genomic-files -d '{"acl": ["abc", "123"], "urls": ["s3://abc/abc"], "hashes": {"md5":"e4b246e5bac1f152b3b13047a4876b84"}, "size": 10}' | jq
{
  "_status": {
    "code": 400,
    "message": "could not create genomic_file: {'acl': ['The ACL field has been deprecated. Please use the authz field instead.']}"
  }
}
```

## Migrations

Gen3 Indexd has a migration script that will populate `authz` fields based on the `acl` field. This script will be run to update everything to `authz` policies. After this has occurred, we will be able to manually set all record's `acl` to be empty to ensure that it is not used when determining access to the record.

