### PR TITLE
:sparkles: add snRNAseq experiment strategy

### DIFF
--- a/dataservice/api/sequencing_experiment/schemas.py
+++ b/dataservice/api/sequencing_experiment/schemas.py
@@ -16,7 +16,7 @@ from dataservice.extensions import ma
 EXPERIMENT_STRATEGY_ENUM = {'WGS', 'WXS', 'RNA-Seq', 'miRNA-Seq',
                             'Linked-Read WGS (10x Chromium)',
                             'Targeted Sequencing', 'Methylation',
-                            'Panel', 'Single Cell RNA-Seq', 'Other'}
+                            'Panel', 'scRNA-Seq', 'snRNA-Seq', 'Other'}
 PLATFORM_ENUM = {'Illumina', 'SOLiD', 'LS454', 'Ion Torrent',
                  'Complete Genomics', 'PacBio', 'ONT', 'Other'}
 LIBRARY_STRAND_ENUM = {'Stranded', 'Unstranded', 'First Stranded',


### PR DESCRIPTION
add snRNAseq as valid experiment strategy value, and update Single Cell RNA-Seq to match structure of other values: scRNAseq

note: there are 30 existing sequencing experiment rows that have "Single Cell RNA-Seq" as the experiment strategy value. We have been notified that these should have been registered as snRNAseq (single nucleus) not single cell. I am patching those today so they will have the value snRNAseq. So, even though I am updating the structure of the Single Cell RNA-Seq value to be scRNAseq in kf utils and the data service, I will not be creating any cases of conflict where the existing data values in the kf db are mis-aligned with the constraints in the API.

This PR also adds the value snRNAseq to ensure that the new value for the "fixed" sequencing experiment rows is a valid enumeration in both the ingest library and data service