### PR TITLE
⬆️ update builder from alpine 3.7 -> 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        python:3-alpine3.7 as builder
+FROM        python:3.7.17-alpine3.18 as builder
 
 WORKDIR     /app
 


### PR DESCRIPTION
# Context
Recently, we made a change to build scripts to remove unnecessary packages from internal build scripts. One of these introduced a dependency for alpine images to be on 3.18 or higher.

The current version of the dataservice builder runs on alpine 3.7, and should be updated.

## Connects 
https://github.com/d3b-infra/aws-ecs-service-type-1-module/pull/291 