### PR TITLE
:heavy_plus_sign: adding ONT WGS strategy enum

### DIFF
--- a/dataservice/api/sequencing_experiment/schemas.py
+++ b/dataservice/api/sequencing_experiment/schemas.py
@@ -20,7 +20,8 @@ EXPERIMENT_STRATEGY_ENUM = {'WGS', 'WXS', 'RNA-Seq', 'miRNA-Seq',
                             'Circular Consensus Sequencing RNA-Seq',
                             'Circular Consensus Sequencing WGS',
                             'Continuous Long Reads RNA-Seq',
-                            'Continuous Long Reads WGS'}
+                            'Continuous Long Reads WGS'
+                            'ONT WGS'}
 PLATFORM_ENUM = {'Illumina', 'SOLiD', 'LS454', 'Ion Torrent',
                  'Complete Genomics', 'PacBio', 'ONT', 'Other'}
 LIBRARY_STRAND_ENUM = {'Stranded', 'Unstranded', 'First Stranded',


### PR DESCRIPTION
adding ONT WGS as seq strategy for use with long reads files. Was left out of the previous release mistakenly