### PR TITLE
✨ Add Sample and Container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ ENV/
 
 # hidden Mac Desktop Services Store files
 .DS_Store
+
+# vim
+*.swo 
+*.swp

--- a/dataservice/__init__.py
+++ b/dataservice/__init__.py
@@ -19,6 +19,8 @@ from dataservice.api.family_relationship.models import FamilyRelationship
 from dataservice.api.outcome.models import Outcome
 from dataservice.api.phenotype.models import Phenotype
 from dataservice.api.biospecimen.models import Biospecimen
+from dataservice.api.sample.models import Sample
+from dataservice.api.container.models import Container
 from dataservice.api.diagnosis.models import Diagnosis
 from dataservice.api.genomic_file.models import GenomicFile
 from dataservice.api.read_group.models import (

--- a/dataservice/api/__init__.py
+++ b/dataservice/api/__init__.py
@@ -22,8 +22,12 @@ from dataservice.api.task_genomic_file import (
 )
 from dataservice.api.family_relationship import FamilyRelationshipAPI
 from dataservice.api.family_relationship import FamilyRelationshipListAPI
+from dataservice.api.sample import SampleAPI
+from dataservice.api.sample import SampleListAPI
 from dataservice.api.biospecimen import BiospecimenAPI
 from dataservice.api.biospecimen import BiospecimenListAPI
+from dataservice.api.container import ContainerAPI
+from dataservice.api.container import ContainerListAPI
 from dataservice.api.diagnosis import DiagnosisAPI
 from dataservice.api.diagnosis import DiagnosisListAPI
 from dataservice.api.outcome import OutcomeAPI
@@ -56,6 +60,7 @@ from dataservice.api.biospecimen_diagnosis import (
     BiospecimenDiagnosisAPI,
     BiospecimenDiagnosisListAPI
 )
+
 from dataservice.api.study.models import Study
 
 

--- a/dataservice/api/biospecimen/models.py
+++ b/dataservice/api/biospecimen/models.py
@@ -2,6 +2,7 @@ from dataservice.extensions import db
 from dataservice.api.common.model import Base, KfId
 from dataservice.api.biospecimen_genomic_file.models import (
     BiospecimenGenomicFile)
+from dataservice.api.container.models import Container
 from dataservice.api.diagnosis.models import Diagnosis
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy import event
@@ -134,6 +135,8 @@ class Biospecimen(db.Model, Base):
     biospecimen_genomic_files = db.relationship(BiospecimenGenomicFile,
                                                 backref='biospecimen',
                                                 cascade='all, delete-orphan')
+    containers = db.relationship(Container, backref='biospecimen',
+                                 cascade='all, delete-orphan')
 
 
 class BiospecimenDiagnosis(db.Model, Base):

--- a/dataservice/api/biospecimen/schemas.py
+++ b/dataservice/api/biospecimen/schemas.py
@@ -21,7 +21,7 @@ PRESERVATION_METHOD_ENUM = {
     'EDTA',
     'FFPE',
     'Fresh',
-    'Frozen',
+    'Flash Frozen',
     'OCT',
     'Snap Frozen'
 }
@@ -90,7 +90,8 @@ class BiospecimenSchema(BaseSchema):
         collection_url = 'api.biospecimens_list'
         exclude = (BaseSchema.Meta.exclude +
                    ('participant', 'sequencing_center') +
-                   ('biospecimen_genomic_files', 'biospecimen_diagnoses'))
+                   ('biospecimen_genomic_files', 'biospecimen_diagnoses') +
+                   ('containers',))
 
     _links = ma.Hyperlinks({
         'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
@@ -105,7 +106,9 @@ class BiospecimenSchema(BaseSchema):
         'diagnoses': ma.URLFor('api.diagnoses_list',
                                biospecimen_id='<kf_id>'),
         'genomic_files': ma.URLFor('api.genomic_files_list',
-                                   biospecimen_id='<kf_id>')
+                                   biospecimen_id='<kf_id>'),
+        'containers': ma.URLFor('api.containers_list',
+                                biospecimen_id='<kf_id>'),
     })
 
 

--- a/dataservice/api/biospecimen/schemas.py
+++ b/dataservice/api/biospecimen/schemas.py
@@ -21,7 +21,7 @@ PRESERVATION_METHOD_ENUM = {
     'EDTA',
     'FFPE',
     'Fresh',
-    'Flash Frozen',
+    'Frozen',
     'OCT',
     'Snap Frozen'
 }

--- a/dataservice/api/container/README.md
+++ b/dataservice/api/container/README.md
@@ -1,0 +1,10 @@
+
+ID Prefix: `CT`
+
+The Container essentially represents the Biospecimen. There should be 
+a 1-to-1 relationship between Container and Biospecimen
+
+This Container is being added in order to represent the Sample, Container
+concepts and their parent child relationship without affecting the
+current Biospecimen entity
+

--- a/dataservice/api/container/__init__.py
+++ b/dataservice/api/container/__init__.py
@@ -1,0 +1,2 @@
+from dataservice.api.container.resources import ContainerAPI
+from dataservice.api.container.resources import ContainerListAPI

--- a/dataservice/api/container/models.py
+++ b/dataservice/api/container/models.py
@@ -29,6 +29,10 @@ class Container(db.Model, Base):
         db.Text(),
         doc='Name given to aliquot by contributor'
     )
+    volume_ul = db.Column(
+        db.Float(),
+        doc='The volume of the aliquot container in microliters'
+    )
     specimen_status = db.Column(
         db.Text(),
         doc='Whether container was shipped, sequenced, etc'

--- a/dataservice/api/container/models.py
+++ b/dataservice/api/container/models.py
@@ -4,18 +4,25 @@ from dataservice.api.common.model import Base, KfId
 
 class Container(db.Model, Base):
     """
-    Container entity
-
-    This table is being added in order to represent the Sample, Container
-    concepts and their parent child relationship without affecting the
-    current Biospecimen entity
+    Container - a distinct portion of a Sample
 
     The Container can be thought of as synonymous with Biospecimen. There
     should be a 1-to-1 relationship between Container and Biospecimen
 
+    Background:
+
+    The current Biospecimen table does not adequately model the hierarchical
+    relationship between specimen groups and specimens. The Sample and
+    Container tables have been created to fill in this gap.
+
+    A Sample is a biologically equivalent group of specimens. A Container
+    represents one of the specimens in the Sample's group of specimens.
+
+    The Sample and Container tables were created in order to minimize any
+    changes to the existing Biospecimen table.
+
     :param kf_id: Unique id given by the Kid's First DCC
-    :param external_aliquot_id: Name given to aliquot by contributor. Will be
-    populated from the related Biospecimen
+    :param external_id: Name given to aliquot by contributor
     :param specimen_status: Whether the container was shipped, sequenced, etc
     """
 
@@ -25,9 +32,9 @@ class Container(db.Model, Base):
     # Enforce the 1-to-1 relationship between Biospecimen and Container
     __table_args__ = (db.UniqueConstraint('biospecimen_id', ),)
 
-    external_aliquot_id = db.Column(
+    external_id = db.Column(
         db.Text(),
-        doc='Name given to aliquot by contributor'
+        doc='Name or ID given to biospecimen by contributor'
     )
     volume_ul = db.Column(
         db.Float(),

--- a/dataservice/api/container/models.py
+++ b/dataservice/api/container/models.py
@@ -1,0 +1,47 @@
+from dataservice.extensions import db
+from dataservice.api.common.model import Base, KfId
+
+
+class Container(db.Model, Base):
+    """
+    Container entity
+
+    This table is being added in order to represent the Sample, Container
+    concepts and their parent child relationship without affecting the
+    current Biospecimen entity
+
+    The Container can be thought of as synonymous with Biospecimen. There
+    should be a 1-to-1 relationship between Container and Biospecimen
+
+    :param kf_id: Unique id given by the Kid's First DCC
+    :param external_aliquot_id: Name given to aliquot by contributor. Will be
+    populated from the related Biospecimen
+    :param specimen_status: Whether the container was shipped, sequenced, etc
+    """
+
+    __tablename__ = 'container'
+    __prefix__ = 'CT'
+
+    # Enforce the 1-to-1 relationship between Biospecimen and Container
+    __table_args__ = (db.UniqueConstraint('biospecimen_id', ),)
+
+    external_aliquot_id = db.Column(
+        db.Text(),
+        doc='Name given to aliquot by contributor'
+    )
+    specimen_status = db.Column(
+        db.Text(),
+        doc='Whether container was shipped, sequenced, etc'
+    )
+    biospecimen_id = db.Column(
+        KfId(),
+        db.ForeignKey('biospecimen.kf_id'),
+        nullable=False,
+        doc='The kf_id of the container\'s specimen'
+    )
+    sample_id = db.Column(
+        KfId(),
+        db.ForeignKey('sample.kf_id'),
+        nullable=False,
+        doc='The kf_id of the container\'s sample'
+    )

--- a/dataservice/api/container/resources.py
+++ b/dataservice/api/container/resources.py
@@ -1,0 +1,169 @@
+from flask import abort, request
+from marshmallow import ValidationError
+from webargs.flaskparser import use_args
+
+from dataservice.extensions import db
+from dataservice.api.common.pagination import paginated, Pagination
+from dataservice.api.container.models import (
+    Container,
+)
+from dataservice.api.container.schemas import (
+    ContainerSchema,
+)
+from dataservice.api.common.views import CRUDView
+from dataservice.api.common.schemas import filter_schema_factory
+
+
+class ContainerListAPI(CRUDView):
+    """
+    Container REST API
+    """
+    endpoint = 'containers_list'
+    rule = '/containers'
+    schemas = {'Container': ContainerSchema}
+
+    @paginated
+    @use_args(filter_schema_factory(ContainerSchema),
+              locations=('query',))
+    def get(self, filter_params, after, limit):
+        """
+        Get all containers
+        ---
+        description: Get all containers
+        template:
+          path:
+            get_list.yml
+          properties:
+            resource:
+              Container
+        """
+        # Get and remove special filter params that are not attributes of model
+        study_id = filter_params.pop('study_id', None)
+
+        # Apply filter params
+        q = (Container.query
+             .filter_by(**filter_params))
+
+        # Apply study_id filter and diagnosis_id filter
+        from dataservice.api.participant.models import Participant
+        from dataservice.api.biospecimen.models import Biospecimen
+
+        if study_id:
+            q = (q.join(Container.biospecimen)
+                 .join(Biospecimen.participant)
+                 .filter(Participant.study_id == study_id))
+
+        return (ContainerSchema(many=True)
+                .jsonify(Pagination(q, after, limit)))
+
+    def post(self):
+        """
+        Create a new container
+        ---
+        template:
+          path:
+            new_resource.yml
+          properties:
+            resource:
+              Container
+        """
+
+        body = request.get_json(force=True)
+
+        # Deserialize
+        try:
+            s = ContainerSchema(strict=True).load(body).data
+        # Request body not valid
+        except ValidationError as e:
+            abort(400, 'could not create container: {}'.format(e.messages))
+
+        # Add to and save in database
+        db.session.add(s)
+        db.session.commit()
+
+        return ContainerSchema(201, 'container {} created'
+                               .format(s.kf_id)).jsonify(s), 201
+
+
+class ContainerAPI(CRUDView):
+    """
+    Container REST API
+    """
+    endpoint = 'containers'
+    rule = '/containers/<string:kf_id>'
+    schemas = {'Container': ContainerSchema}
+
+    def get(self, kf_id):
+        """
+        Get containers by id
+        ---
+        template:
+          path:
+            get_by_id.yml
+          properties:
+            resource:
+              Container
+        """
+        sa = Container.query.get(kf_id)
+        if sa is None:
+            abort(404, 'could not find {} `{}`'
+                  .format('container', kf_id))
+        return ContainerSchema().jsonify(sa)
+
+    def patch(self, kf_id):
+        """
+        Update an existing container. Allows partial update of resource
+        ---
+        template:
+          path:
+            update_by_id.yml
+          properties:
+            resource:
+              Container
+        """
+        sa = Container.query.get(kf_id)
+        if sa is None:
+            abort(404, 'could not find {} `{}`'
+                  .format('container', kf_id))
+
+        # Partial update - validate but allow missing required fields
+        body = request.get_json(force=True) or {}
+        try:
+            sa = ContainerSchema(strict=True).load(body, instance=sa,
+                                                   partial=True).data
+        except ValidationError as err:
+            abort(400, 'could not update container: {}'.format(err.messages))
+
+        db.session.add(sa)
+        db.session.commit()
+
+        return ContainerSchema(
+            200, 'container {} updated'.format(sa.kf_id)
+        ).jsonify(sa), 200
+
+    def delete(self, kf_id):
+        """
+        Delete container by id
+
+        Deletes a container given a Kids First id
+        ---
+        template:
+          path:
+            delete_by_id.yml
+          properties:
+            resource:
+              Container
+        """
+
+        # Check if container exists
+        sa = Container.query.get(kf_id)
+        if sa is None:
+            abort(404, 'could not find {} `{}`'
+                  .format('container', kf_id))
+
+        # Save in database
+        db.session.delete(sa)
+        db.session.commit()
+
+        return ContainerSchema(200, 'container {} deleted'
+                               .format(sa.kf_id)).jsonify(sa), 200

--- a/dataservice/api/container/schemas.py
+++ b/dataservice/api/container/schemas.py
@@ -8,8 +8,9 @@ from dataservice.api.common.schemas import BaseSchema
 class ContainerSchema(BaseSchema):
     biospecimen_id = field_for(Container, 'biospecimen_id', required=True,
                                load_only=True)
-    sample_id = field_for(Container, 'sample_id', required=True,
-                               load_only=True)
+    sample_id = field_for(
+        Container, 'sample_id', required=True, load_only=True
+    )
 
     class Meta(BaseSchema.Meta):
         model = Container

--- a/dataservice/api/container/schemas.py
+++ b/dataservice/api/container/schemas.py
@@ -1,0 +1,26 @@
+from marshmallow_sqlalchemy import field_for
+
+from dataservice.extensions import ma
+from dataservice.api.container.models import Container
+from dataservice.api.common.schemas import BaseSchema
+
+
+class ContainerSchema(BaseSchema):
+    biospecimen_id = field_for(Container, 'biospecimen_id', required=True,
+                               load_only=True)
+    sample_id = field_for(Container, 'sample_id', required=True,
+                               load_only=True)
+
+    class Meta(BaseSchema.Meta):
+        model = Container
+        resource_url = 'api.containers'
+        collection_url = 'api.containers_list'
+        exclude = (BaseSchema.Meta.exclude +
+                   ('biospecimen', ))
+
+    _links = ma.Hyperlinks({
+        'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
+        'collection': ma.URLFor(Meta.collection_url),
+        'biospecimen': ma.URLFor('api.biospecimens', kf_id='<biospecimen_id>'),
+        'sample': ma.URLFor('api.samples', kf_id='<sample_id>'),
+    })

--- a/dataservice/api/participant/models.py
+++ b/dataservice/api/participant/models.py
@@ -8,6 +8,7 @@ from dataservice.api.biospecimen.models import Biospecimen
 from dataservice.api.diagnosis.models import Diagnosis
 from dataservice.api.outcome.models import Outcome
 from dataservice.api.phenotype.models import Phenotype
+from dataservice.api.sample.models import Sample
 
 
 class AliasGroup(db.Model, Base):
@@ -81,6 +82,10 @@ class Participant(db.Model, Base):
                                  cascade='all, delete-orphan',
                                  backref=db.backref('participant',
                                                     lazy=True))
+    samples = db.relationship(Sample,
+                              cascade='all, delete-orphan',
+                              backref=db.backref('participant',
+                                                 lazy=True))
 
     study_id = db.Column(KfId(),
                          db.ForeignKey('study.kf_id'),

--- a/dataservice/api/participant/schemas.py
+++ b/dataservice/api/participant/schemas.py
@@ -56,7 +56,9 @@ class ParticipantSchema(BaseSchema):
         collection_url = 'api.participants_list'
         exclude = (BaseSchema.Meta.exclude +
                    ('study', 'family') +
-                   ('diagnoses', 'phenotypes', 'outcomes', 'biospecimens'))
+                   ('diagnoses', 'phenotypes', 'outcomes', 'biospecimens',
+                    'samples')
+                   )
 
     _links = ma.Hyperlinks({
         'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
@@ -70,6 +72,8 @@ class ParticipantSchema(BaseSchema):
                               participant_id='<kf_id>'),
         'biospecimens': ma.URLFor('api.biospecimens_list',
                                   participant_id='<kf_id>'),
+        'samples': ma.URLFor('api.samples_list',
+                             participant_id='<kf_id>'),
         'family_relationships': ma.URLFor('api.family_relationships_list',
                                           participant_id='<kf_id>')
     })

--- a/dataservice/api/sample/__init__.py
+++ b/dataservice/api/sample/__init__.py
@@ -1,0 +1,2 @@
+from dataservice.api.sample.resources import SampleAPI
+from dataservice.api.sample.resources import SampleListAPI

--- a/dataservice/api/sample/models.py
+++ b/dataservice/api/sample/models.py
@@ -18,7 +18,7 @@ class Sample(db.Model, Base):
 
     :param kf_id: Unique id given by the Kid's First DCC
     :param external_id: Name given to sample by contributor
-    :param sample_event_key: An identifier that represents when the sample 
+    :param sample_event_key: An identifier that represents when the sample
     was drawn
     :param composition : The cellular composition of the sample.
     :param tissue_type: description of the kind of tissue collected
@@ -35,7 +35,7 @@ class Sample(db.Model, Base):
     :param preservation_method: Text term that represents the method used
            to preserve the sample
     :param method_of_sample_procurement: Text term that represents the method
-           used to extract the analytes from the sample 
+           used to extract the analytes from the sample
     """
 
     __tablename__ = 'sample'

--- a/dataservice/api/sample/models.py
+++ b/dataservice/api/sample/models.py
@@ -1,0 +1,88 @@
+from dataservice.extensions import db
+from dataservice.api.common.model import Base, KfId
+from dataservice.api.container.models import Container
+from sqlalchemy import event
+
+
+class Sample(db.Model, Base):
+    """
+    Sample entity
+
+    This table is being added in order to represent the Sample, Container
+    concepts and their parent child relationship without affecting the
+    current Biospecimen entity. The Container can be thought of as
+    synonymous with Biospecimen.
+
+    The Sample represents a group of biologically equivalent biospecimens/
+    containers
+
+    :param kf_id: Unique id given by the Kid's First DCC
+    :param external_id: Name given to sample by contributor
+    :param sample_event_key: An identifier that represents when the sample 
+    was drawn
+    :param composition : The cellular composition of the sample.
+    :param tissue_type: description of the kind of tissue collected
+           with respect to disease status or proximity to tumor tissue
+    :param anatomical_location : The name of the primary disease site
+           of the submitted tumor sample
+    :param analyte_type: Text term that represents the kind of molecular
+           specimen analyte
+    :param concentration_mg_per_ml: The concentration of an analyte or aliquot
+           extracted from the sample or sample portion, measured in
+           milligrams per milliliter
+    :param volume_ul: The volume in microliters (ul) of the aliquots derived
+           from the analyte(s) shipped for sequencing and characterization
+    :param preservation_method: Text term that represents the method used
+           to preserve the sample
+    :param method_of_sample_procurement: Text term that represents the method
+           used to extract the analytes from the sample 
+    """
+
+    __tablename__ = 'sample'
+    __prefix__ = 'SA'
+
+    external_id = db.Column(
+        db.Text(),
+        doc='Name given to sample by contributor'
+    )
+    tissue_type = db.Column(
+        db.Text(),
+        doc='Description of the kind of sample collected'
+    )
+    composition = db.Column(
+        db.Text(),
+        doc='The cellular composition of the sample'
+    )
+    anatomical_location = db.Column(
+        db.Text(),
+        doc='The anatomical location of collection'
+    )
+    analyte_type = db.Column(
+        db.Text(),
+        doc='The molecular description of the sample'
+    )
+    concentration_mg_per_ml = db.Column(
+        db.Float(),
+        doc='The concentration of the sample'
+    )
+    volume_ul = db.Column(
+        db.Float(),
+        doc='The volume of the sample'
+    )
+    method_of_sample_procurement = db.Column(
+        db.Text(),
+        doc='The method used to procure the sample used to extract '
+        'analyte(s)'
+    )
+    preservation_method = db.Column(
+        db.Text(),
+        doc='Text term that represents the method used to preserve the sample'
+    )
+    participant_id = db.Column(KfId(),
+                               db.ForeignKey('participant.kf_id'),
+                               nullable=False,
+                               doc='The kf_id of the sample\'s donor')
+    containers = db.relationship(Container,
+                                 cascade='all, delete-orphan',
+                                 backref=db.backref('sample',
+                                                    lazy=True))

--- a/dataservice/api/sample/models.py
+++ b/dataservice/api/sample/models.py
@@ -45,6 +45,10 @@ class Sample(db.Model, Base):
         db.Text(),
         doc='Name given to sample by contributor'
     )
+    sample_event_key = db.Column(
+        db.Text(),
+        doc='Identifier for event when sample was first drawn'
+    )
     tissue_type = db.Column(
         db.Text(),
         doc='Description of the kind of sample collected'

--- a/dataservice/api/sample/models.py
+++ b/dataservice/api/sample/models.py
@@ -6,15 +6,19 @@ from sqlalchemy import event
 
 class Sample(db.Model, Base):
     """
-    Sample entity
+    Sample - a biologically equivalent group of specimens
 
-    This table is being added in order to represent the Sample, Container
-    concepts and their parent child relationship without affecting the
-    current Biospecimen entity. The Container can be thought of as
-    synonymous with Biospecimen.
+    Background:
 
-    The Sample represents a group of biologically equivalent biospecimens/
-    containers
+    The current Biospecimen table does not adequately model the hierarchical
+    relationship between specimen groups and specimens. The Sample and
+    Container tables have been created to fill in this gap.
+
+    A Sample is a biologically equivalent group of specimens. A Container
+    represents one of the specimens in the Sample's group of specimens.
+
+    The Sample and Container tables were created in order to minimize any
+    changes to the existing Biospecimen table.
 
     :param kf_id: Unique id given by the Kid's First DCC
     :param external_id: Name given to sample by contributor
@@ -43,7 +47,7 @@ class Sample(db.Model, Base):
 
     external_id = db.Column(
         db.Text(),
-        doc='Name given to sample by contributor'
+        doc='Name or ID given to sample by contributor'
     )
     sample_event_key = db.Column(
         db.Text(),

--- a/dataservice/api/sample/models.py
+++ b/dataservice/api/sample/models.py
@@ -86,3 +86,10 @@ class Sample(db.Model, Base):
                                  cascade='all, delete-orphan',
                                  backref=db.backref('sample',
                                                     lazy=True))
+
+
+@event.listens_for(Container, 'after_delete')
+def delete_orphans(mapper, connection, state):
+    q = (db.session.query(Container)
+         .filter(~Sample.containers.any()))
+    q.delete(synchronize_session='fetch')

--- a/dataservice/api/sample/models.py
+++ b/dataservice/api/sample/models.py
@@ -90,6 +90,6 @@ class Sample(db.Model, Base):
 
 @event.listens_for(Container, 'after_delete')
 def delete_orphans(mapper, connection, state):
-    q = (db.session.query(Container)
+    q = (db.session.query(Sample)
          .filter(~Sample.containers.any()))
     q.delete(synchronize_session='fetch')

--- a/dataservice/api/sample/resources.py
+++ b/dataservice/api/sample/resources.py
@@ -1,0 +1,168 @@
+from flask import abort, request
+from marshmallow import ValidationError
+from webargs.flaskparser import use_args
+
+from dataservice.extensions import db
+from dataservice.api.common.pagination import paginated, Pagination
+from dataservice.api.sample.models import (
+    Sample,
+)
+from dataservice.api.sample.schemas import (
+    SampleSchema,
+)
+from dataservice.api.common.views import CRUDView
+from dataservice.api.common.schemas import filter_schema_factory
+
+
+class SampleListAPI(CRUDView):
+    """
+    Sample REST API
+    """
+    endpoint = 'samples_list'
+    rule = '/samples'
+    schemas = {'Sample': SampleSchema}
+
+    @paginated
+    @use_args(filter_schema_factory(SampleSchema),
+              locations=('query',))
+    def get(self, filter_params, after, limit):
+        """
+        Get all samples
+        ---
+        description: Get all samples
+        template:
+          path:
+            get_list.yml
+          properties:
+            resource:
+              Sample
+        """
+        # Get and remove special filter params that are not attributes of model
+        study_id = filter_params.pop('study_id', None)
+
+        # Apply filter params
+        q = (Sample.query
+             .filter_by(**filter_params))
+
+
+        # Apply study_id filter and diagnosis_id filter
+        from dataservice.api.participant.models import Participant
+
+        if study_id:
+            q = (q.join(Participant.samples)
+                 .filter(Participant.study_id == study_id))
+
+        return (SampleSchema(many=True)
+                .jsonify(Pagination(q, after, limit)))
+
+    def post(self):
+        """
+        Create a new sample
+        ---
+        template:
+          path:
+            new_resource.yml
+          properties:
+            resource:
+              Sample
+        """
+
+        body = request.get_json(force=True)
+
+        # Deserialize
+        try:
+            s = SampleSchema(strict=True).load(body).data
+        # Request body not valid
+        except ValidationError as e:
+            abort(400, 'could not create sample: {}'.format(e.messages))
+
+        # Add to and save in database
+        db.session.add(s)
+        db.session.commit()
+
+        return SampleSchema(201, 'sample {} created'
+                                 .format(s.kf_id)).jsonify(s), 201
+
+
+class SampleAPI(CRUDView):
+    """
+    Sample REST API
+    """
+    endpoint = 'samples'
+    rule = '/samples/<string:kf_id>'
+    schemas = {'Sample': SampleSchema}
+
+    def get(self, kf_id):
+        """
+        Get samples by id
+        ---
+        template:
+          path:
+            get_by_id.yml
+          properties:
+            resource:
+              Sample
+        """
+        sa = Sample.query.get(kf_id)
+        if sa is None:
+            abort(404, 'could not find {} `{}`'
+                  .format('sample', kf_id))
+        return SampleSchema().jsonify(sa)
+
+    def patch(self, kf_id):
+        """
+        Update an existing sample. Allows partial update of resource
+        ---
+        template:
+          path:
+            update_by_id.yml
+          properties:
+            resource:
+              Sample
+        """
+        sa = Sample.query.get(kf_id)
+        if sa is None:
+            abort(404, 'could not find {} `{}`'
+                  .format('sample', kf_id))
+
+        # Partial update - validate but allow missing required fields
+        body = request.get_json(force=True) or {}
+        try:
+            sa = SampleSchema(strict=True).load(body, instance=sa,
+                                                partial=True).data
+        except ValidationError as err:
+            abort(400, 'could not update sample: {}'.format(err.messages))
+
+        db.session.add(sa)
+        db.session.commit()
+
+        return SampleSchema(
+            200, 'sample {} updated'.format(sa.kf_id)
+        ).jsonify(sa), 200
+
+    def delete(self, kf_id):
+        """
+        Delete sample by id
+
+        Deletes a sample given a Kids First id
+        ---
+        template:
+          path:
+            delete_by_id.yml
+          properties:
+            resource:
+              Sample
+        """
+
+        # Check if sample exists
+        sa = Sample.query.get(kf_id)
+        if sa is None:
+            abort(404, 'could not find {} `{}`'
+                  .format('sample', kf_id))
+
+        # Save in database
+        db.session.delete(sa)
+        db.session.commit()
+
+        return SampleSchema(200, 'sample {} deleted'
+                                 .format(sa.kf_id)).jsonify(sa), 200

--- a/dataservice/api/sample/resources.py
+++ b/dataservice/api/sample/resources.py
@@ -44,7 +44,6 @@ class SampleListAPI(CRUDView):
         q = (Sample.query
              .filter_by(**filter_params))
 
-
         # Apply study_id filter and diagnosis_id filter
         from dataservice.api.participant.models import Participant
 

--- a/dataservice/api/sample/schemas.py
+++ b/dataservice/api/sample/schemas.py
@@ -1,0 +1,36 @@
+from marshmallow_sqlalchemy import field_for
+from marshmallow import (
+    fields,
+    validates
+)
+
+from dataservice.extensions import ma
+from dataservice.api.sample.models import Sample
+from dataservice.api.common.schemas import BaseSchema
+from dataservice.api.common.validation import validate_age
+from dataservice.api.common.custom_fields import DateOrDatetime
+from dataservice.api.common.validation import (
+    validate_positive_number,
+    enum_validation_generator,
+    validate_kf_id,
+    list_validation_generator
+)
+
+
+class SampleSchema(BaseSchema):
+    participant_id = field_for(Sample, 'participant_id', required=True,
+                               load_only=True)
+
+    class Meta(BaseSchema.Meta):
+        model = Sample
+        resource_url = 'api.samples'
+        collection_url = 'api.samples_list'
+        exclude = (BaseSchema.Meta.exclude + ('participant', 'containers'))
+
+    _links = ma.Hyperlinks({
+        'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
+        'collection': ma.URLFor(Meta.collection_url),
+        'participant': ma.URLFor('api.participants', kf_id='<participant_id>'),
+        'containers': ma.URLFor('api.containers_list',
+                                sample_id='<kf_id>'),
+    })

--- a/dataservice/api/sample/schemas.py
+++ b/dataservice/api/sample/schemas.py
@@ -1,20 +1,8 @@
 from marshmallow_sqlalchemy import field_for
-from marshmallow import (
-    fields,
-    validates
-)
 
 from dataservice.extensions import ma
 from dataservice.api.sample.models import Sample
 from dataservice.api.common.schemas import BaseSchema
-from dataservice.api.common.validation import validate_age
-from dataservice.api.common.custom_fields import DateOrDatetime
-from dataservice.api.common.validation import (
-    validate_positive_number,
-    enum_validation_generator,
-    validate_kf_id,
-    list_validation_generator
-)
 
 
 class SampleSchema(BaseSchema):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,7 +262,7 @@ def make_entities(client):
         for i, (sample, biospecimen) in enumerate(
             zip(samples, biospecimens)
         ):
-            ct = Container(external_aliquot_id=f"container-{i}")
+            ct = Container(external_id=f"container-{i}")
             ct.sample = sample
             ct.biospecimen = biospecimen
             _entities[Container].append(ct)

--- a/tests/container/test_container_models.py
+++ b/tests/container/test_container_models.py
@@ -1,0 +1,50 @@
+from dataservice.extensions import db
+from dataservice.api.container.models import Container
+from tests.utils import FlaskTestCase
+
+from tests.create import make_container
+
+
+class ContainerModelTest(FlaskTestCase):
+    """
+    Test container database model
+    """
+
+    def test_create_container(self):
+        """
+        Test creation of a container
+        """
+        c = make_container(specimen_status="available")
+        container = Container.query.filter_by(
+            external_aliquot_id=c.external_aliquot_id,
+        ).one()
+
+        assert container.external_aliquot_id == "container-01"
+        assert container.biospecimen.external_sample_id == "bs1"
+
+    def test_delete_container(self):
+        """
+        Test that a container is removed
+        """
+        c = make_container()
+        container = Container.query.filter_by(
+            external_aliquot_id=c.external_aliquot_id,
+        ).one()
+        db.session.delete(container)
+        db.session.commit()
+
+        assert Container.query.count() == 0
+
+    def test_update_container(self):
+        """
+        Test that container properties may be updated
+        """
+        c = make_container()
+        assert c.external_aliquot_id == 'container-01'
+
+        c.external_aliquot_id = 'container-02'
+        db.session.add(c)
+        db.session.commit()
+
+        assert Container.query.get(
+            c.kf_id).external_aliquot_id == 'container-02'

--- a/tests/container/test_container_models.py
+++ b/tests/container/test_container_models.py
@@ -16,10 +16,10 @@ class ContainerModelTest(FlaskTestCase):
         """
         c = make_container(specimen_status="available")
         container = Container.query.filter_by(
-            external_aliquot_id=c.external_aliquot_id,
+            external_id=c.external_id,
         ).one()
 
-        assert container.external_aliquot_id == "container-01"
+        assert container.external_id == "container-01"
         assert container.biospecimen.external_sample_id == "bs1"
 
     def test_delete_container(self):
@@ -28,7 +28,7 @@ class ContainerModelTest(FlaskTestCase):
         """
         c = make_container()
         container = Container.query.filter_by(
-            external_aliquot_id=c.external_aliquot_id,
+            external_id=c.external_id,
         ).one()
         db.session.delete(container)
         db.session.commit()
@@ -40,11 +40,11 @@ class ContainerModelTest(FlaskTestCase):
         Test that container properties may be updated
         """
         c = make_container()
-        assert c.external_aliquot_id == 'container-01'
+        assert c.external_id == 'container-01'
 
-        c.external_aliquot_id = 'container-02'
+        c.external_id = 'container-02'
         db.session.add(c)
         db.session.commit()
 
         assert Container.query.get(
-            c.kf_id).external_aliquot_id == 'container-02'
+            c.kf_id).external_id == 'container-02'

--- a/tests/container/test_container_resources.py
+++ b/tests/container/test_container_resources.py
@@ -23,7 +23,7 @@ class ContainerTest(FlaskTestCase):
         bs = create.make_biospecimen()
         sp = create.make_sample()
         data = {
-            "external_aliquot_id": "container-01",
+            "external_id": "container-01",
             "specimen_status": "available",
             "biospecimen_id": bs.kf_id,
             "sample_id": sp.kf_id,
@@ -43,13 +43,13 @@ class ContainerTest(FlaskTestCase):
 
         resp = resp["results"]
         container = Container.query.get(resp['kf_id'])
-        assert container.external_aliquot_id == resp['external_aliquot_id']
+        assert container.external_id == resp['external_id']
 
     def test_get_container(self):
         """
         Test retrieving a container by id
         """
-        s = create.make_container(external_aliquot_id='foobar')
+        s = create.make_container(external_id='foobar')
 
         response = self.client.get(
             url_for(CONTAINERS_URL, kf_id=s.kf_id),
@@ -61,13 +61,13 @@ class ContainerTest(FlaskTestCase):
         resp = resp['results']
         container = Container.query.get(resp["kf_id"])
         assert container
-        assert container.external_aliquot_id == resp["external_aliquot_id"]
+        assert container.external_id == resp["external_id"]
 
     def test_get_all_containers(self):
         """
         Test retrieving all containers
         """
-        create.make_container(external_aliquot_id='TEST')
+        create.make_container(external_id='TEST')
 
         response = self.client.get(
             url_for(CONTAINERS_LIST_URL),
@@ -85,9 +85,9 @@ class ContainerTest(FlaskTestCase):
         Test updating an existing container
         """
         orig = Container.query.count()
-        s = create.make_container(external_aliquot_id='TEST')
+        s = create.make_container(external_id='TEST')
         body = {
-            'external_aliquot_id': 'NEWID',
+            'external_id': 'NEWID',
         }
         assert (orig + 1) == Container.query.count()
 
@@ -106,8 +106,8 @@ class ContainerTest(FlaskTestCase):
         # Content - check only patched fields are updated
         container = Container.query.get(s.kf_id)
         assert (
-            container.external_aliquot_id ==
-            resp['results']['external_aliquot_id']
+            container.external_id ==
+            resp['results']['external_id']
         )
 
     def test_delete_container(self):
@@ -115,7 +115,7 @@ class ContainerTest(FlaskTestCase):
         Test deleting a container by id
         """
         orig = Container.query.count()
-        s = create.make_container(external_aliquot_id='TEST')
+        s = create.make_container(external_id='TEST')
         kf_id = s.kf_id
 
         response = self.client.delete(url_for(CONTAINERS_URL,

--- a/tests/container/test_container_resources.py
+++ b/tests/container/test_container_resources.py
@@ -1,13 +1,8 @@
 import json
-from datetime import datetime
-from dateutil import parser, tz
-from pprint import pprint
 
 from flask import url_for
 
-from dataservice.extensions import db
 from dataservice.api.container.models import Container
-from dataservice.api.study.models import Study
 
 from tests.utils import FlaskTestCase
 from tests import create
@@ -72,7 +67,7 @@ class ContainerTest(FlaskTestCase):
         """
         Test retrieving all containers
         """
-        s = create.make_container(external_aliquot_id='TEST')
+        create.make_container(external_aliquot_id='TEST')
 
         response = self.client.get(
             url_for(CONTAINERS_LIST_URL),
@@ -127,7 +122,6 @@ class ContainerTest(FlaskTestCase):
                                               kf_id=kf_id),
                                       headers=self._api_headers())
 
-        resp = json.loads(response.data.decode('utf-8'))
         assert response.status_code == 200
         assert orig == Container.query.count()
 
@@ -135,5 +129,5 @@ class ContainerTest(FlaskTestCase):
                                            kf_id=kf_id),
                                    headers=self._api_headers())
 
-        resp = json.loads(response.data.decode('utf-8'))
+        json.loads(response.data.decode('utf-8'))
         assert response.status_code == 404

--- a/tests/container/test_container_resources.py
+++ b/tests/container/test_container_resources.py
@@ -1,0 +1,139 @@
+import json
+from datetime import datetime
+from dateutil import parser, tz
+from pprint import pprint
+
+from flask import url_for
+
+from dataservice.extensions import db
+from dataservice.api.container.models import Container
+from dataservice.api.study.models import Study
+
+from tests.utils import FlaskTestCase
+from tests import create
+
+CONTAINERS_URL = 'api.containers'
+CONTAINERS_LIST_URL = 'api.containers_list'
+
+
+class ContainerTest(FlaskTestCase):
+    """
+    Test container api endpoints
+    """
+
+    def test_post_container(self):
+        """
+        Test creating a new container
+        """
+        bs = create.make_biospecimen()
+        sp = create.make_sample()
+        data = {
+            "external_aliquot_id": "container-01",
+            "specimen_status": "available",
+            "biospecimen_id": bs.kf_id,
+            "sample_id": sp.kf_id,
+        }
+        # Send post request
+        response = self.client.post(url_for(CONTAINERS_LIST_URL),
+                                    data=json.dumps(data),
+                                    headers=self._api_headers())
+
+        assert response.status_code == 201
+
+        resp = json.loads(response.data.decode('utf-8'))
+        assert "container" in resp['_status']['message']
+        assert "created" in resp['_status']['message']
+        assert "biospecimen" in resp["_links"]
+        assert "sample" in resp["_links"]
+
+        resp = resp["results"]
+        container = Container.query.get(resp['kf_id'])
+        assert container.external_aliquot_id == resp['external_aliquot_id']
+
+    def test_get_container(self):
+        """
+        Test retrieving a container by id
+        """
+        s = create.make_container(external_aliquot_id='foobar')
+
+        response = self.client.get(
+            url_for(CONTAINERS_URL, kf_id=s.kf_id),
+            headers=self._api_headers()
+        )
+        resp = json.loads(response.data.decode('utf-8'))
+        assert response.status_code == 200
+
+        resp = resp['results']
+        container = Container.query.get(resp["kf_id"])
+        assert container
+        assert container.external_aliquot_id == resp["external_aliquot_id"]
+
+    def test_get_all_containers(self):
+        """
+        Test retrieving all containers
+        """
+        s = create.make_container(external_aliquot_id='TEST')
+
+        response = self.client.get(
+            url_for(CONTAINERS_LIST_URL),
+            headers=self._api_headers()
+        )
+        assert response.status_code == 200
+        response = json.loads(response.data.decode('utf-8'))
+        content = response.get('results')
+
+        assert isinstance(content, list)
+        assert len(content) == 1
+
+    def test_patch_container(self):
+        """
+        Test updating an existing container
+        """
+        orig = Container.query.count()
+        s = create.make_container(external_aliquot_id='TEST')
+        body = {
+            'external_aliquot_id': 'NEWID',
+        }
+        assert (orig + 1) == Container.query.count()
+
+        response = self.client.patch(url_for(CONTAINERS_URL,
+                                             kf_id=s.kf_id),
+                                     headers=self._api_headers(),
+                                     data=json.dumps(body))
+        # Status code
+        assert response.status_code == 200
+
+        # Message
+        resp = json.loads(response.data.decode('utf-8'))
+        assert "container" in resp['_status']['message']
+        assert "updated" in resp['_status']['message']
+
+        # Content - check only patched fields are updated
+        container = Container.query.get(s.kf_id)
+        assert (
+            container.external_aliquot_id ==
+            resp['results']['external_aliquot_id']
+        )
+
+    def test_delete_container(self):
+        """
+        Test deleting a container by id
+        """
+        orig = Container.query.count()
+        s = create.make_container(external_aliquot_id='TEST')
+        kf_id = s.kf_id
+
+        response = self.client.delete(url_for(CONTAINERS_URL,
+                                              kf_id=kf_id),
+                                      headers=self._api_headers())
+
+        resp = json.loads(response.data.decode('utf-8'))
+        assert response.status_code == 200
+        assert orig == Container.query.count()
+
+        response = self.client.get(url_for(CONTAINERS_URL,
+                                           kf_id=kf_id),
+                                   headers=self._api_headers())
+
+        resp = json.loads(response.data.decode('utf-8'))
+        assert response.status_code == 404

--- a/tests/create.py
+++ b/tests/create.py
@@ -1,0 +1,133 @@
+from datetime import datetime
+
+from dataservice.extensions import db
+from dataservice.api.container.models import Container
+from dataservice.api.sample.models import Sample
+from dataservice.api.biospecimen.models import Biospecimen
+from dataservice.api.sequencing_center.models import SequencingCenter
+from dataservice.api.participant.models import Participant
+from dataservice.api.study.models import Study
+
+
+def make_study(external_id="phs001", **kwargs):
+    """
+    Make study
+    """
+    s = Study.query.filter_by(external_id=external_id).one_or_none()
+    if not s:
+        kwargs["external_id"] = external_id
+        s = Study(**kwargs)
+        db.session.add(s)
+        db.session.commit()
+
+    return s
+
+
+def make_participant(external_id='p1', **kwargs):
+    """
+    Make a sample
+    """
+    s = make_study()
+    p = Participant.query.filter_by(external_id=external_id).one_or_none()
+    if not p:
+        kwargs["external_id"] = external_id
+        p = Participant(**kwargs)
+        s.participants.extend([p])
+        db.session.add(s)
+        db.session.commit()
+
+    return p
+
+
+def make_biospecimen(
+    external_sample_id='bs1', external_aliquot_id='bs1', **kwargs
+):
+    """
+    Make a biospecimen
+    """
+    bs = Biospecimen.query.filter_by(
+        external_sample_id=external_sample_id,
+        external_aliquot_id=external_aliquot_id,
+    ).one_or_none()
+    if not bs:
+        dt = datetime.now()
+        p = make_participant()
+        sc = make_seq_center()
+        body = {
+            'external_sample_id': external_sample_id,
+            'external_aliquot_id': external_aliquot_id,
+            'source_text_tissue_type': 'Normal',
+            'composition': 'blood',
+            'source_text_anatomical_site': 'Brain',
+            'age_at_event_days': 456,
+            'source_text_tumor_descriptor': 'Metastatic',
+            'shipment_origin': 'CORIELL',
+            'analyte_type': 'DNA',
+            'concentration_mg_per_ml': 100.0,
+            'volume_ul': 12.67,
+            'shipment_date': dt,
+            'uberon_id_anatomical_site': 'UBERON:0000955',
+            'spatial_descriptor': 'left side',
+            'ncit_id_tissue_type': 'Test',
+            'ncit_id_anatomical_site': 'C12439',
+            'consent_type': 'GRU-IRB',
+            'dbgap_consent_code': 'phs00000.c1',
+            'preservation_method': 'Frozen',
+            "participant_id": p.kf_id,
+            "sequencing_center_id": sc.kf_id
+        }
+        body.update(kwargs)
+        bs = Biospecimen(**body)
+        db.session.add(bs)
+        db.session.commit()
+
+    return bs
+
+
+def make_container(external_aliquot_id='container-01', sample=None, **kwargs):
+    """
+    Make a container
+    """
+    ct = Container.query.filter_by(
+        external_aliquot_id=external_aliquot_id
+    ).one_or_none()
+    if not ct:
+        bs = make_biospecimen()
+        if not sample:
+            sample = make_sample()
+        kwargs["external_aliquot_id"] = external_aliquot_id
+        ct = Container(**kwargs, biospecimen=bs, sample=sample)
+        db.session.add(ct)
+        db.session.commit()
+
+    return ct
+
+
+def make_sample(external_id='sample-01', **kwargs):
+    """
+    Make a sample
+    """
+    s = Sample.query.filter_by(external_id=external_id).one_or_none()
+    if not s:
+        p1 = make_participant()
+        kwargs["external_id"] = external_id
+        s = Sample(**kwargs)
+        s.participant = p1
+        db.session.add(s)
+        db.session.commit()
+
+    return s
+
+
+def make_seq_center(name="Baylor", **kwargs):
+    """
+    Make a sequencing_center
+    """
+    sc = SequencingCenter.query.filter_by(name=name).one_or_none()
+    if sc is None:
+        kwargs["name"] = name
+        sc = SequencingCenter(**kwargs)
+    db.session.add(sc)
+    db.session.commit()
+
+    return sc

--- a/tests/create.py
+++ b/tests/create.py
@@ -98,7 +98,7 @@ def make_biospecimen(
 
 
 def make_container(
-    external_aliquot_id='container-01', sample=None, force_create=False,
+    external_id='container-01', sample=None, force_create=False,
     **kwargs
 ):
     """
@@ -108,14 +108,14 @@ def make_container(
         ct = None
     else:
         ct = Container.query.filter_by(
-            external_aliquot_id=external_aliquot_id
+            external_id=external_id
         ).one_or_none()
 
     if not ct:
         bs = make_biospecimen(force_create=True)
         if not sample:
             sample = make_sample()
-        kwargs["external_aliquot_id"] = external_aliquot_id
+        kwargs["external_id"] = external_id
         ct = Container(**kwargs, biospecimen=bs, sample=sample)
         db.session.add(ct)
         db.session.commit()

--- a/tests/create.py
+++ b/tests/create.py
@@ -9,11 +9,15 @@ from dataservice.api.participant.models import Participant
 from dataservice.api.study.models import Study
 
 
-def make_study(external_id="phs001", **kwargs):
+def make_study(external_id="phs001", force_create=False, **kwargs):
     """
     Make study
     """
-    s = Study.query.filter_by(external_id=external_id).one_or_none()
+    if force_create:
+        s = None
+    else:
+        s = Study.query.filter_by(external_id=external_id).one_or_none()
+
     if not s:
         kwargs["external_id"] = external_id
         s = Study(**kwargs)
@@ -23,15 +27,20 @@ def make_study(external_id="phs001", **kwargs):
     return s
 
 
-def make_participant(external_id='p1', **kwargs):
+def make_participant(external_id='p1', force_create=False, **kwargs):
     """
     Make a sample
     """
-    s = make_study()
-    p = Participant.query.filter_by(external_id=external_id).one_or_none()
+    if force_create:
+        p = None
+    else:
+        p = Participant.query.filter_by(external_id=external_id).one_or_none()
+
     if not p:
         kwargs["external_id"] = external_id
         p = Participant(**kwargs)
+
+        s = make_study()
         s.participants.extend([p])
         db.session.add(s)
         db.session.commit()
@@ -40,15 +49,19 @@ def make_participant(external_id='p1', **kwargs):
 
 
 def make_biospecimen(
-    external_sample_id='bs1', external_aliquot_id='bs1', **kwargs
+    external_sample_id='bs1', external_aliquot_id='bs1', force_create=False,
+    **kwargs
 ):
     """
     Make a biospecimen
     """
-    bs = Biospecimen.query.filter_by(
-        external_sample_id=external_sample_id,
-        external_aliquot_id=external_aliquot_id,
-    ).one_or_none()
+    if force_create:
+        bs = None
+    else:
+        bs = Biospecimen.query.filter_by(
+            external_sample_id=external_sample_id,
+            external_aliquot_id=external_aliquot_id,
+        ).one_or_none()
     if not bs:
         dt = datetime.now()
         p = make_participant()
@@ -84,15 +97,22 @@ def make_biospecimen(
     return bs
 
 
-def make_container(external_aliquot_id='container-01', sample=None, **kwargs):
+def make_container(
+    external_aliquot_id='container-01', sample=None, force_create=False,
+    **kwargs
+):
     """
     Make a container
     """
-    ct = Container.query.filter_by(
-        external_aliquot_id=external_aliquot_id
-    ).one_or_none()
+    if force_create:
+        ct = None
+    else:
+        ct = Container.query.filter_by(
+            external_aliquot_id=external_aliquot_id
+        ).one_or_none()
+
     if not ct:
-        bs = make_biospecimen()
+        bs = make_biospecimen(force_create=True)
         if not sample:
             sample = make_sample()
         kwargs["external_aliquot_id"] = external_aliquot_id
@@ -103,11 +123,15 @@ def make_container(external_aliquot_id='container-01', sample=None, **kwargs):
     return ct
 
 
-def make_sample(external_id='sample-01', **kwargs):
+def make_sample(external_id='sample-01', force_create=False, **kwargs):
     """
     Make a sample
     """
-    s = Sample.query.filter_by(external_id=external_id).one_or_none()
+    if force_create:
+        s = None
+    else:
+        s = Sample.query.filter_by(external_id=external_id).one_or_none()
+
     if not s:
         p1 = make_participant()
         kwargs["external_id"] = external_id
@@ -119,7 +143,7 @@ def make_sample(external_id='sample-01', **kwargs):
     return s
 
 
-def make_seq_center(name="Baylor", **kwargs):
+def make_seq_center(name="Baylor", force_create=False, **kwargs):
     """
     Make a sequencing_center
     """

--- a/tests/data.json
+++ b/tests/data.json
@@ -68,7 +68,7 @@
       "visible": true
     },
     "/containers": {
-      "external_aliquot_id": "container-01",
+      "external_id": "container-01",
       "specimen_status": "availble",
       "visible": true
     },
@@ -228,7 +228,7 @@
     },
     "/containers": {
       "valid": {
-        "external_aliquot_id": "foo"
+        "external_id": "foo"
       },
       "invalid": []
     },

--- a/tests/data.json
+++ b/tests/data.json
@@ -55,6 +55,23 @@
       "preservation_method": "Fresh",
       "visible": true
     },
+    "/samples": {
+      "external_id": "Biospecimen_0",
+      "tissue_type": "normal",
+      "composition": "Blood",
+      "anatomical_location": "arm",
+      "analyte_type": "DNA",
+      "concentration_mg_per_ml": 200.0,
+      "volume_ul": 13.99,
+      "method_of_sample_procurement": "Biopsy",
+      "preservation_method": "Fresh",
+      "visible": true
+    },
+    "/containers": {
+      "external_aliquot_id": "container-01",
+      "specimen_status": "availble",
+      "visible": true
+    },
     "/diagnoses": {
       "external_id": "d0",
       "diagnosis_category": "Structural Birth Defect",
@@ -200,6 +217,20 @@
         { "method_of_sample_procurement": "foo" },
         { "preservation_method": "foo" }
       ]
+    },
+    "/samples": {
+      "valid": {
+        "analyte_type": "RNA",
+        "method_of_sample_procurement": "Autopsy",
+        "preservation_method": "Frozen"
+      },
+      "invalid": []
+    },
+    "/containers": {
+      "valid": {
+        "external_aliquot_id": "foo"
+      },
+      "invalid": []
     },
     "/diagnoses": {
       "valid": {

--- a/tests/sample/test_sample_models.py
+++ b/tests/sample/test_sample_models.py
@@ -26,7 +26,7 @@ class SampleModelTest(FlaskTestCase):
         """
         s = make_sample()
         make_container(
-            external_aliquot_id="c1", sample=s, force_create=True
+            external_id="c1", sample=s, force_create=True
         )
         sample = Sample.query.filter_by(external_id=s.external_id).one()
         db.session.delete(sample)
@@ -44,10 +44,10 @@ class SampleModelTest(FlaskTestCase):
         s1 = make_sample(external_id="s01", force_create=True)
         s2 = make_sample(external_id="s02", force_create=True)
         make_container(
-            external_aliquot_id="c1", sample=s1, force_create=True
+            external_id="c1", sample=s1, force_create=True
         )
         make_container(
-            external_aliquot_id="c2", sample=s2, force_create=True
+            external_id="c2", sample=s2, force_create=True
         )
         assert len(s1.containers) == 1
 

--- a/tests/sample/test_sample_models.py
+++ b/tests/sample/test_sample_models.py
@@ -1,8 +1,9 @@
 from dataservice.extensions import db
 from dataservice.api.sample.models import Sample
+from dataservice.api.container.models import Container
 from tests.utils import FlaskTestCase
 
-from tests.create import make_sample
+from tests.create import make_sample, make_container
 
 
 class SampleModelTest(FlaskTestCase):
@@ -21,14 +22,18 @@ class SampleModelTest(FlaskTestCase):
 
     def test_delete_sample(self):
         """
-        Test that a sample is removed
+        Test that a sample and its containers are removed
         """
         s = make_sample()
+        ct = make_container(
+            external_aliquot_id="c1", sample=s, force_create=True
+        )
         sample = Sample.query.filter_by(external_id=s.external_id).one()
         db.session.delete(sample)
         db.session.commit()
 
         assert Sample.query.count() == 0
+        assert Container.query.count() == 0
 
     def test_delete_container_orphan(self):
         """
@@ -36,12 +41,30 @@ class SampleModelTest(FlaskTestCase):
         are deleted
         """
         # Make two samples with containers
+        s1 = make_sample(external_id="s01", force_create=True)
+        s2 = make_sample(external_id="s02", force_create=True)
+        c1 = make_container(
+            external_aliquot_id="c1", sample=s1, force_create=True
+        )
+        c2 = make_container(
+            external_aliquot_id="c2", sample=s2, force_create=True
+        )
+        assert len(s1.containers) == 1
 
         # Make orphan sample
+        result = Sample.query.filter_by(external_id="s01").one()
+        for ct in result.containers:
+            db.session.delete(ct)
+        db.session.commit()
 
         # Check that orphan sample is deleted
+        result = Sample.query.filter_by(external_id="s01").one_or_none()
+        assert result is None
 
         # Check that other sample still exists
+        result = Sample.query.filter_by(external_id="s02").one_or_none()
+        assert result
+        assert len(result.containers) == 1
 
     def test_update_sample(self):
         """

--- a/tests/sample/test_sample_models.py
+++ b/tests/sample/test_sample_models.py
@@ -25,7 +25,7 @@ class SampleModelTest(FlaskTestCase):
         Test that a sample and its containers are removed
         """
         s = make_sample()
-        ct = make_container(
+        make_container(
             external_aliquot_id="c1", sample=s, force_create=True
         )
         sample = Sample.query.filter_by(external_id=s.external_id).one()
@@ -43,10 +43,10 @@ class SampleModelTest(FlaskTestCase):
         # Make two samples with containers
         s1 = make_sample(external_id="s01", force_create=True)
         s2 = make_sample(external_id="s02", force_create=True)
-        c1 = make_container(
+        make_container(
             external_aliquot_id="c1", sample=s1, force_create=True
         )
-        c2 = make_container(
+        make_container(
             external_aliquot_id="c2", sample=s2, force_create=True
         )
         assert len(s1.containers) == 1

--- a/tests/sample/test_sample_models.py
+++ b/tests/sample/test_sample_models.py
@@ -1,0 +1,57 @@
+from dataservice.extensions import db
+from dataservice.api.sample.models import Sample
+from tests.utils import FlaskTestCase
+
+from tests.create import make_sample
+
+
+class SampleModelTest(FlaskTestCase):
+    """
+    Test sample database model
+    """
+
+    def test_create_sample(self):
+        """
+        Test creation of a sample
+        """
+        s = make_sample()
+        sample = Sample.query.filter_by(external_id=s.external_id).one()
+
+        assert sample.participant.external_id == "p1"
+
+    def test_delete_sample(self):
+        """
+        Test that a sample is removed
+        """
+        s = make_sample()
+        sample = Sample.query.filter_by(external_id=s.external_id).one()
+        db.session.delete(sample)
+        db.session.commit()
+
+        assert Sample.query.count() == 0
+
+    def test_delete_container_orphan(self):
+        """
+        Test that a sample is deleted when all related containers
+        are deleted
+        """
+        # Make two samples with containers
+
+        # Make orphan sample
+
+        # Check that orphan sample is deleted
+
+        # Check that other sample still exists
+
+    def test_update_sample(self):
+        """
+        Test that sample properties may be updated
+        """
+        s = make_sample()
+        assert s.external_id == 'sample-01'
+
+        s.external_id = 'sample-02'
+        db.session.add(s)
+        db.session.commit()
+
+        assert Sample.query.get(s.kf_id).external_id == 'sample-02'

--- a/tests/sample/test_sample_resources.py
+++ b/tests/sample/test_sample_resources.py
@@ -1,12 +1,8 @@
 import json
-from datetime import datetime
-from dateutil import parser, tz
 
 from flask import url_for
 
-from dataservice.extensions import db
 from dataservice.api.sample.models import Sample
-from dataservice.api.study.models import Study
 
 from tests.utils import FlaskTestCase
 from tests.create import make_sample, make_participant
@@ -66,7 +62,7 @@ class SampleTest(FlaskTestCase):
         """
         Test retrieving all samples
         """
-        s = make_sample(external_id='TEST')
+        make_sample(external_id='TEST')
 
         response = self.client.get(
             url_for(SAMPLES_LIST_URL),
@@ -118,7 +114,6 @@ class SampleTest(FlaskTestCase):
                                               kf_id=kf_id),
                                       headers=self._api_headers())
 
-        resp = json.loads(response.data.decode('utf-8'))
         assert response.status_code == 200
         assert orig == Sample.query.count()
 
@@ -126,5 +121,4 @@ class SampleTest(FlaskTestCase):
                                            kf_id=kf_id),
                                    headers=self._api_headers())
 
-        resp = json.loads(response.data.decode('utf-8'))
         assert response.status_code == 404

--- a/tests/sample/test_sample_resources.py
+++ b/tests/sample/test_sample_resources.py
@@ -1,0 +1,130 @@
+import json
+from datetime import datetime
+from dateutil import parser, tz
+
+from flask import url_for
+
+from dataservice.extensions import db
+from dataservice.api.sample.models import Sample
+from dataservice.api.study.models import Study
+
+from tests.utils import FlaskTestCase
+from tests.create import make_sample, make_participant
+
+SAMPLES_URL = 'api.samples'
+SAMPLES_LIST_URL = 'api.samples_list'
+
+
+class SampleTest(FlaskTestCase):
+    """
+    Test sample api endpoints
+    """
+
+    def test_post_sample(self):
+        """
+        Test creating a new sample
+        """
+        p = make_participant()
+        data = {
+            "external_id": "sample-01",
+            "participant_id": p.kf_id
+        }
+        # Send post request
+        response = self.client.post(url_for(SAMPLES_LIST_URL),
+                                    data=json.dumps(data),
+                                    headers=self._api_headers())
+
+        assert response.status_code == 201
+
+        resp = json.loads(response.data.decode('utf-8'))
+        assert "sample" in resp['_status']['message']
+        assert "created" in resp['_status']['message']
+
+        resp = resp['results']
+        sample = Sample.query.get(resp['kf_id'])
+        assert sample.external_id == resp['external_id']
+
+    def test_get_sample(self):
+        """
+        Test retrieving a sample by id
+        """
+        s = make_sample(external_id='TESTXXX')
+
+        response = self.client.get(
+            url_for(SAMPLES_URL, kf_id=s.kf_id),
+            headers=self._api_headers()
+        )
+        resp = json.loads(response.data.decode('utf-8'))
+        assert response.status_code == 200
+
+        resp = resp['results']
+        sample = Sample.query.get(resp["kf_id"])
+        assert sample
+        assert sample.external_id == resp["external_id"]
+
+    def test_get_all_samples(self):
+        """
+        Test retrieving all samples
+        """
+        s = make_sample(external_id='TEST')
+
+        response = self.client.get(
+            url_for(SAMPLES_LIST_URL),
+            headers=self._api_headers()
+        )
+        assert response.status_code == 200
+        response = json.loads(response.data.decode('utf-8'))
+        content = response.get('results')
+
+        assert isinstance(content, list)
+        assert len(content) == 1
+
+    def test_patch_sample(self):
+        """
+        Test updating an existing sample
+        """
+        orig = Sample.query.count()
+        s = make_sample(external_id='TEST')
+        body = {
+            'external_id': 'NEWID',
+        }
+        assert (orig + 1) == Sample.query.count()
+
+        response = self.client.patch(url_for(SAMPLES_URL,
+                                             kf_id=s.kf_id),
+                                     headers=self._api_headers(),
+                                     data=json.dumps(body))
+        # Status code
+        assert response.status_code == 200
+
+        # Message
+        resp = json.loads(response.data.decode('utf-8'))
+        assert "sample" in resp['_status']['message']
+        assert "updated" in resp['_status']['message']
+
+        # Content - check only patched fields are updated
+        sample = Sample.query.get(s.kf_id)
+        assert sample.external_id == resp['results']['external_id']
+
+    def test_delete_sample(self):
+        """
+        Test deleting a sample by id
+        """
+        orig = Sample.query.count()
+        s = make_sample(external_id='TEST')
+        kf_id = s.kf_id
+
+        response = self.client.delete(url_for(SAMPLES_URL,
+                                              kf_id=kf_id),
+                                      headers=self._api_headers())
+
+        resp = json.loads(response.data.decode('utf-8'))
+        assert response.status_code == 200
+        assert orig == Sample.query.count()
+
+        response = self.client.get(url_for(SAMPLES_URL,
+                                           kf_id=kf_id),
+                                   headers=self._api_headers())
+
+        resp = json.loads(response.data.decode('utf-8'))
+        assert response.status_code == 404

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,6 +84,8 @@ class TestAPI:
         ('/outcomes', ['participant']),
         ('/diagnoses', ['participant', 'biospecimens']),
         ('/biospecimens', ['participant', 'sequencing_center', 'diagnoses']),
+        ('/samples', ['participant']),
+        ('/containers', ['biospecimen', 'sample']),
         ('/sequencing-experiments', ['sequencing_center', 'genomic_files']),
         ('/genomic-files', ['read_groups', 'sequencing_experiments']),
         ('/read-groups', ['genomic_files']),
@@ -349,6 +351,8 @@ class TestAPI:
                                  ('/genomic-files', 'urls'),
                                  ('/genomic-files', 'hashes'),
                                  ('/diagnoses', 'participant_id'),
+                                 ('/containers', 'biospecimen_id'),
+                                 ('/containers', 'sample_id'),
                                  ('/sequencing-centers', 'name')
                              ])
     def test_missing_required_params(self, client, entities, endpoint,
@@ -385,6 +389,8 @@ class TestAPI:
                               ('/study-files', 'study_id'),
                               ('/diagnoses', 'participant_id'),
                               ('/biospecimens', 'participant_id'),
+                              ('/containers', 'biospecimen_id'),
+                              ('/samples', 'participant_id'),
                               ('/tasks', 'cavatica_app_id'),
                               ('/task-genomic-files',
                                'task_id'),

--- a/tests/test_filter_params.py
+++ b/tests/test_filter_params.py
@@ -10,6 +10,7 @@ from tests.conftest import (
     MAX_PAGE_LIMIT,
     DEFAULT_PAGE_LIMIT
 )
+from pprint import pprint
 
 
 class TestFilterParams:
@@ -57,6 +58,9 @@ class TestFilterParams:
         resp = json.loads(response.data.decode('utf-8'))
 
         # Check status code
+        print(endpoint)
+        pprint(filter_params)
+        pprint(resp)
         assert response.status_code == 200
         assert resp['limit'] == DEFAULT_PAGE_LIMIT
         assert len(resp['results']) == min(expected_total, DEFAULT_PAGE_LIMIT)

--- a/tests/test_filter_params.py
+++ b/tests/test_filter_params.py
@@ -10,7 +10,6 @@ from tests.conftest import (
     MAX_PAGE_LIMIT,
     DEFAULT_PAGE_LIMIT
 )
-from pprint import pprint
 
 
 class TestFilterParams:

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -144,7 +144,7 @@ class TestPagination:
             db.session.add(sample)
 
             container = Container(
-                external_aliquot_id="container-01"
+                external_id="container-01"
             )
             container.biospecimen = samp
             container.sample = sample

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -14,6 +14,8 @@ from dataservice.api.outcome.models import Outcome
 from dataservice.api.phenotype.models import Phenotype
 from dataservice.api.diagnosis.models import Diagnosis
 from dataservice.api.biospecimen.models import Biospecimen
+from dataservice.api.sample.models import Sample
+from dataservice.api.container.models import Container
 from dataservice.api.genomic_file.models import GenomicFile
 from dataservice.api.read_group.models import (
     ReadGroup,
@@ -134,8 +136,20 @@ class TestPagination:
             samp = Biospecimen(analyte_type='an analyte',
                                sequencing_center_id=seq_cen.kf_id,
                                participant=p)
-            db.session.add(samp)
             p.biospecimens = [samp]
+            db.session.add(samp)
+
+            sample = Sample(external_id="sample-01")
+            p.samples = [sample]
+            db.session.add(sample)
+
+            container = Container(
+                external_aliquot_id="container-01"
+            )
+            container.biospecimen = samp
+            container.sample = sample
+            db.session.add(container)
+            db.session.flush()
 
             gf = GenomicFile(**gf_kwargs)
             db.session.add(gf)
@@ -172,6 +186,8 @@ class TestPagination:
         ('/study-files', MAX_PAGE_LIMIT+1),
         ('/investigators', 1),
         ('/biospecimens', int(MAX_PAGE_LIMIT/2)),
+        ('/samples', int(MAX_PAGE_LIMIT/2)),
+        ('/containers', int(MAX_PAGE_LIMIT/2)),
         ('/sequencing-experiments', int(MAX_PAGE_LIMIT/2)),
         ('/diagnoses', int(MAX_PAGE_LIMIT/2)),
         ('/outcomes', int(MAX_PAGE_LIMIT/2)),


### PR DESCRIPTION
## Motivation

The current biospecimen model does not adequately capture lineage of biospecimens or biological equivalency among groups of biospecimens. This information is important for several reasons. One reason is when someone needs to know the total remaining quantity of  aliquots/biospecimens that can be used for additional sequencing or processing. 

## Approach
Introduce 2 new tables: `Sample` and `Container`. These tables will be populated by deriving containers and samples from the incoming Biospecimen in a POST/PATCH request (#645). 

- `Sample`: represents a biologically distinct amount of material from a single person. A sample will also be used to group biospecimens (also known as aliquots or containers) that are biologically equivalent. 
- `Container`: an extracted portion of a Sample

![sample-container-erd](https://github.com/kids-first/kf-api-dataservice/assets/10283712/bcaee8c0-6094-4f11-aae4-108b512e975d)

**Note:** We wanted to take this approach to minimize or eliminate any changes to the current biospecimen table so that current functionality is not disrupted in any way.

### Database
- Create a `Sample` table 
- Create a `Container` table

#### Delete Life Cycles
- When a Participant is deleted its child Samples are also deleted
- When a Biospecimen is deleted its associated Container is deleted
- When a Sample is deleted its child Containers are also deleted
- When a Sample has 0 child Containers, it will be deleted. This is considered an orphan sample

### API
- Implement REST API for both `Sample` and `Container`
- In the future we may remove POST/PUT/PATCH/DELETE from the API for these two concepts since eventually the create, update, delete lifecycles will be managed internally by the API.

## Todo

- [ ] Add db schema migrations once finalized
- [x] (#645) Implement logic that will automatically create/update/delete rows in `Sample` and `Container` each time a Biospecimen is created/updated
