### PR TITLE
🔥 Don't delete biospecimen on sample delete

### DIFF
--- a/dataservice/api/sample/models.py
+++ b/dataservice/api/sample/models.py
@@ -105,10 +105,9 @@ class Sample(db.Model, Base):
                                db.ForeignKey('participant.kf_id'),
                                nullable=False,
                                doc='The kf_id of the sample\'s donor')
-    biospecimens = db.relationship(Biospecimen,
-                                   cascade='all, delete-orphan',
-                                   backref=db.backref('sample',
-                                                      lazy=True))
+    biospecimens = db.relationship(
+        Biospecimen, backref=db.backref('sample', lazy=True)
+    )
 
 
 @event.listens_for(Biospecimen, 'after_delete')

--- a/tests/sample/test_sample_models.py
+++ b/tests/sample/test_sample_models.py
@@ -22,18 +22,21 @@ class SampleModelTest(FlaskTestCase):
 
     def test_delete_sample(self):
         """
-        Test that a sample and its biospecimens are removed
+        Test that a sample and its biospecimen's sample_id is set to null 
         """
         s = make_sample()
-        make_biospecimen(
+        b = make_biospecimen(
             external_sample_id="c1", sample=s, force_create=True
         )
+        bs_kf_id = b.kf_id
         sample = Sample.query.filter_by(external_id=s.external_id).one()
         db.session.delete(sample)
         db.session.commit()
 
         assert Sample.query.count() == 0
-        assert Biospecimen.query.count() == 0
+        assert Biospecimen.query.count() == 1
+
+        assert Biospecimen.query.get(bs_kf_id).sample_id is None
 
     def test_delete_sample_orphan(self):
         """


### PR DESCRIPTION
## Motivation 
Right now when you delete a sample it will cascade delete all the biospecimens under it. This seems dangerous because it is not extremely clear to everyone using Dataservice that Sample = Parent Biospecimen. Everyone knows that Participant is the parent of Biospecimen and so we know not to delete Participant since it will cascade delete everything.

## Approach
Remove the cascade delete configuration on Sample. When you delete a Sample, any child Biospecimen's will still exist and their sample_id field will be set to null.

This is the way Family works. You can delete Family without deleting everything under it