### PR TITLE
♻️ Don't delete samples with 0 biospecimens

### DIFF
--- a/dataservice/api/sample/models.py
+++ b/dataservice/api/sample/models.py
@@ -110,11 +110,3 @@ class Sample(db.Model, Base):
     )
 
 
-@event.listens_for(Biospecimen, 'after_delete')
-def delete_orphans(mapper, connection, state):
-    """
-    Delete samples with 0 child biospecimens
-    """
-    q = (db.session.query(Sample)
-         .filter(~Sample.biospecimens.any()))
-    q.delete(synchronize_session='fetch')

--- a/dataservice/api/sample/models.py
+++ b/dataservice/api/sample/models.py
@@ -30,13 +30,9 @@ col_mapping = {
 
 class Sample(db.Model, Base):
     """
-    Sample - a biologically equivalent group of specimens
+    Sample - a biologically distinct unit
 
-    Background:
-
-    The current Biospecimen table does not adequately model the hierarchical
-    relationship between specimen groups and specimens. The Sample table has
-    been created to fill in this gap.
+    The Biospecimen represents an aliquot or portion of a Sample
 
     :param kf_id: Unique id given by the Kid's First DCC
     :param external_id: Name given to sample by contributor
@@ -108,5 +104,3 @@ class Sample(db.Model, Base):
     biospecimens = db.relationship(
         Biospecimen, backref=db.backref('sample', lazy=True)
     )
-
-

--- a/tests/sample/test_sample_models.py
+++ b/tests/sample/test_sample_models.py
@@ -38,9 +38,9 @@ class SampleModelTest(FlaskTestCase):
 
         assert Biospecimen.query.get(bs_kf_id).sample_id is None
 
-    def test_delete_sample_orphan(self):
+    def test_no_delete_sample_orphan(self):
         """
-        Test that a sample is deleted when all related biospecimens
+        Test that a sample is NOT deleted when all related biospecimens
         are deleted
         """
         # Make two samples with biospecimens
@@ -60,13 +60,13 @@ class SampleModelTest(FlaskTestCase):
             db.session.delete(ct)
         db.session.commit()
 
-        # Check that orphan sample is deleted
+        # Check that orphan sample is not deleted
         result = Sample.query.filter_by(external_id="s01").one_or_none()
-        assert result is None
+        assert result.kf_id
 
         # Check that other sample still exists
         result = Sample.query.filter_by(external_id="s02").one_or_none()
-        assert result
+        assert result.kf_id
         assert len(result.biospecimens) == 1
 
     def test_update_sample(self):


### PR DESCRIPTION
## Motivation
Up until now we considered samples with 0 child biospecimens to be invalid, and therefore the API would automatically delete them. 

Now that we can track an aribitrary sample tree via the sample relationships table, we know we will have samples that have 0 child biospecimens. We don't want to automatically delete these anymore.

## Approach
Remove the auto-delete functionality that deletes samples with 0 child biospecimens

## Future
We may want to add auto-delete logic that deletes samples that have 0 child biospecimens _and_ 0 child samples. This can be done in another PR. Before we do this we should discuss whether it is valid to have a "leaf" sample in a sample tree which has 0 containers/aliquots yet.  