### PR TITLE
🐛 Fix query sample relationships

### DIFF
--- a/dataservice/api/sample_relationship/schemas.py
+++ b/dataservice/api/sample_relationship/schemas.py
@@ -4,6 +4,7 @@ from marshmallow import (
     validates
 )
 
+from dataservice.api.common.custom_fields import PatchedURLFor
 from dataservice.api.sample_relationship.models import SampleRelationship
 from dataservice.api.common.schemas import BaseSchema
 from dataservice.api.common.validation import validate_kf_id
@@ -12,10 +13,10 @@ from dataservice.extensions import ma
 
 class SampleRelationshipSchema(BaseSchema):
     parent_id = field_for(SampleRelationship, 'parent_id',
-                          required=True,
+                          required=False,
                           load_only=True, example='SA_B048J5')
     child_id = field_for(SampleRelationship, 'child_id',
-                         required=True,
+                         required=False,
                          load_only=True, example='SA_B048J6')
 
     class Meta(BaseSchema.Meta):
@@ -27,9 +28,9 @@ class SampleRelationshipSchema(BaseSchema):
     _links = ma.Hyperlinks({
         'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
         'collection': ma.URLFor(Meta.collection_url),
-        'parent': ma.URLFor('api.samples',
+        'parent': PatchedURLFor('api.samples',
                             kf_id='<parent_id>'),
-        'child': ma.URLFor('api.samples',
+        'child': PatchedURLFor('api.samples',
                            kf_id='<child_id>')
     })
 

--- a/dataservice/api/sample_relationship/schemas.py
+++ b/dataservice/api/sample_relationship/schemas.py
@@ -28,10 +28,8 @@ class SampleRelationshipSchema(BaseSchema):
     _links = ma.Hyperlinks({
         'self': ma.URLFor(Meta.resource_url, kf_id='<kf_id>'),
         'collection': ma.URLFor(Meta.collection_url),
-        'parent': PatchedURLFor('api.samples',
-                            kf_id='<parent_id>'),
-        'child': PatchedURLFor('api.samples',
-                           kf_id='<child_id>')
+        'parent': PatchedURLFor('api.samples', kf_id='<parent_id>'),
+        'child': PatchedURLFor('api.samples', kf_id='<child_id>')
     })
 
 

--- a/tests/sample_relationship/common.py
+++ b/tests/sample_relationship/common.py
@@ -28,7 +28,12 @@ def create_relationships():
             child=samples[1],
             external_child_id=samples[1].external_id,
         )
-        sample_relationships.append(sr)
+        root = samples[0] 
+        root_relationship = SampleRelationship(
+            parent=None,
+            child=root
+        )
+        sample_relationships.extend([sr, root_relationship])
         p.samples.extend(samples)
         if i % 2 == 0:
             studies[0].participants.append(p)

--- a/tests/sample_relationship/test_sample_relationship_models.py
+++ b/tests/sample_relationship/test_sample_relationship_models.py
@@ -20,7 +20,7 @@ class ModelTest(FlaskTestCase):
         Test create sample relationships
         """
         create_relationships()
-        assert 4 == SampleRelationship.query.count()
+        assert 8 == SampleRelationship.query.count()
 
     def test_parent_child_cannot_be_equal(self):
         """
@@ -40,7 +40,7 @@ class ModelTest(FlaskTestCase):
             db.session.commit()
         assert "same as" in str(e.value)
         db.session.rollback()
-        assert 4 == SampleRelationship.query.count()
+        assert 8 == SampleRelationship.query.count()
 
         # Case: update
         sr = SampleRelationship.query.first()
@@ -68,7 +68,7 @@ class ModelTest(FlaskTestCase):
             db.session.commit()
         assert "Reverse relationship" in str(e.value)
         db.session.rollback()
-        assert 4 == SampleRelationship.query.count()
+        assert 8 == SampleRelationship.query.count()
 
         # Case: update
         rels = SampleRelationship.query.all()
@@ -111,7 +111,7 @@ class ModelTest(FlaskTestCase):
         sr = rels[0]
         db.session.delete(sr)
         db.session.commit()
-        assert 3 == SampleRelationship.query.count()
+        assert 7 == SampleRelationship.query.count()
 
     def test_delete_via_sample(self):
         """
@@ -122,7 +122,7 @@ class ModelTest(FlaskTestCase):
         sa = sr.parent
         db.session.delete(sa)
         db.session.commit()
-        assert 3 == SampleRelationship.query.count()
+        assert 6 == SampleRelationship.query.count()
 
     def test_foreign_key_constraint(self):
         """
@@ -204,7 +204,7 @@ class ModelTest(FlaskTestCase):
         study_id = studies[0]
 
         # Query all samples
-        assert 4 == SampleRelationship.query_all_relationships().count()
+        assert 8 == SampleRelationship.query_all_relationships().count()
 
         # Query by sample
 
@@ -224,6 +224,6 @@ class ModelTest(FlaskTestCase):
         db.session.add_all([sr1, sr2])
         db.session.commit()
 
-        assert 3 == SampleRelationship.query_all_relationships(
+        assert 4 == SampleRelationship.query_all_relationships(
             sr.parent.kf_id
         ).count()

--- a/tests/sample_relationship/test_sample_relationship_resources.py
+++ b/tests/sample_relationship/test_sample_relationship_resources.py
@@ -57,7 +57,7 @@ class SampleRelationshipTest(FlaskTestCase):
 
         assert sr.parent.kf_id == parent_id
         assert sr.child.kf_id == child_id
-        assert SampleRelationship.query.count() == 5
+        assert SampleRelationship.query.count() == 9
 
     def test_no_multi_parent_samples(self):
         """
@@ -153,7 +153,25 @@ class SampleRelationshipTest(FlaskTestCase):
         # Check response content
         response = json.loads(response.data.decode('utf-8'))
         content = response.get('results')
-        assert len(content) == 4
+        assert len(content) == 8
+
+    def test_get_with_null_parents(self):
+        """
+        Test retrieving all sample_relationships when some have null parents or
+        null children
+        """
+        # Create and save sample_relationship to db
+        _, rels = create_relationships()
+
+        response = self.client.get(url_for(SAMPLE_RELATIONSHIPS_LIST_URL),
+                                   headers=self._api_headers())
+        # Check response status code
+        assert response.status_code == 200
+
+        # Check response content
+        response = json.loads(response.data.decode('utf-8'))
+        content = response.get('results')
+        assert len(content) == 8
 
     def test_patch(self):
         """
@@ -206,7 +224,7 @@ class SampleRelationshipTest(FlaskTestCase):
         response = json.loads(response.data.decode("utf-8"))
 
         # Check database
-        assert SampleRelationship.query.count() == 3
+        assert SampleRelationship.query.count() == 7
 
     def test_special_filter_param(self):
         """
@@ -231,7 +249,7 @@ class SampleRelationshipTest(FlaskTestCase):
         # Check response content
         response = json.loads(response.data.decode('utf-8'))
         content = response.get('results')
-        assert len(content) == 2
+        assert len(content) == 4
 
         # Case 2 - Query by sample_id
         sample_id = rels[0].parent_id
@@ -247,7 +265,7 @@ class SampleRelationshipTest(FlaskTestCase):
         # Check response content
         response = json.loads(response.data.decode('utf-8'))
         content = response.get('results')
-        assert len(content) == 1
+        assert len(content) == 2
 
         # Case 3 - Query by sample_id and other params
         sample_id = rels[0].parent_id

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -354,8 +354,6 @@ class TestAPI:
                                  ('/genomic-files', 'hashes'),
                                  ('/diagnoses', 'participant_id'),
                                  ('/samples', 'participant_id'),
-                                 ('/sample-relationships', 'parent_id'),
-                                 ('/sample-relationships', 'child_id'),
                                  ('/biospecimens', 'analyte_type'),
                                  ('/sequencing-centers', 'name')
                              ])


### PR DESCRIPTION
Querying for sample-relationships by a sample_id would fail if the results contained any relationships where the parent/child is null. We forgot to account for this in developing the sample-relationships API