### PR TITLE
⬆️ Bump Werkzeug from 0.15.3 to 0.15.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ MarkupSafe==0.23
 python-editor==1.0.3
 six==1.11.0
 SQLAlchemy==1.1.15
-Werkzeug==0.15.3
+Werkzeug==0.15.5
 base32-crockford==0.3.0
 gunicorn==19.7.1
 flask-marshmallow==0.8.0


### PR DESCRIPTION
bug fixed in 0.15.4 where message is returned when running `flask db migrate`: 
```sh
TypeError: required field "type_ignores" missing from Module
``` 
bumping to later 0.15 version resolves this issue. Similiar issue and solution from [stackoverflow](https://stackoverflow.com/questions/60140174/basic-flask-app-not-running-typeerror-required-field-type-ignores-missing-fr)

Note that the most recent [version of wz is 3.0.4](https://werkzeug.palletsprojects.com/en/3.0.x/changes/#version-3-0-4)