### PR TITLE
👨🏻‍💻 Always bind all interfaces when app runs in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,32 +44,11 @@ development environment using 1 of 2 options:
 
 - Pro: Quick setup, no installation of dependencies
 - Con: Since everything is running in containers, need to use `docker container exec` to run things in container
-- Con: You'll need to make a couple of small changes to run the dockerized service in debug mode (live updates) 
 
-1. In docker-compose.yml change the following under the `dataservice` block: 
+Follow the instructions in [Run API](#run-api)
 
-```yaml
-    # command: /bin/ash -c "sleep 5; ./bin/run.sh"
-    command: /bin/ash -c "sleep 5; flask db upgrade; ./manage.py"
-
-    port:
-        - "5000:5000"    
-```
-
-2. Bind host to all interfaces in manage.py:
-
-```python
-if __name__ == '__main__':
-    app.run(host="0.0.0.0")
-```
-
-3. Follow the instructions in [Run API](#run-api)
-
-Now your service should be running at http://localhost:5000 inside the 
-docker-compose stack. The changes you made above allow the service to run 
-in **debug mode** which means when you make changes to the code, 
-it should reload the service automatically so that you can see your updates in
-realtime instead of having to bring down the stack and bring it up again.
+Once again your service should be running at http://localhost:5000 inside the 
+docker-compose stack. 
 
 ### Option 2: Develop API on Machine 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,24 +11,28 @@ services:
       POSTGRES_USER: "${DATASERVICE_DB_USER}"
       POSTGRES_PASSWORD: "${DATASERVICE_DB_PASSWORD}"
     ports:
-        - "5432:5432"
+        - "5433:5432"
   dataservice:
     container_name: dataservice
     build: 
       context: .
       target: test
-    command: /bin/ash -c "sleep 5; ./bin/run.sh"
-    # command: /bin/ash -c "sleep 5; flask db upgrade; ./manage.py"
+    # command: /bin/ash -c "sleep 5; ./bin/run.sh"
+    command: /bin/ash -c "sleep 5; flask db upgrade; ./manage.py"
     volumes:
       - .:/app
     ports:
-      - "5000:80"
+      - "5000:5000"
     env_file:
       - .env
     environment:
       FLASK_CONFIG: "${FLASK_CONFIG}"
       FLASK_APP: "${FLASK_APP}"
-      PG_HOST: "${DATASERVICE_PG_HOST}"
+      # NOTE: Only set BIND_ALL_INTERFACES to enabled if running app within
+      # a docker container. Otherwise, you  will make your app accessible to
+      # any IP that can reach machine via its public IP 
+      BIND_ALL_INTERFACES: "enabled"
+      PG_HOST: dataservice_pg
       PG_PORT: "${DATASERVICE_PG_PORT}"
       PG_NAME: "${DATASERVICE_DB}"
       PG_USER: "${DATASERVICE_DB_USER}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_USER: "${DATASERVICE_DB_USER}"
       POSTGRES_PASSWORD: "${DATASERVICE_DB_PASSWORD}"
     ports:
-        - "5433:5432"
+        - "5432:5432"
   dataservice:
     container_name: dataservice
     build: 

--- a/manage.py
+++ b/manage.py
@@ -5,5 +5,10 @@ from dataservice import create_app
 
 app = create_app(os.environ.get('FLASK_CONFIG') or 'default')
 
+BIND_ALL_INTERFACES = os.environ.get("BIND_ALL_INTERFACES")
+host = None
+if BIND_ALL_INTERFACES == "enabled":
+    host = "0.0.0.0"
+
 if __name__ == '__main__':
-    app.run()
+    app.run(host=host)


### PR DESCRIPTION
Make it easier for developers to run the app when they're using docker-compose. 

Previously, the developer had to make some changes to the code in order to run and develop the API inside the docker container. 

The changes here make it so that the developer doesn't have to change anything when running the app in the docker-compose stack.

**NOTE** If running the API in a docker container, binding to all interfaces does not expose your API to the world. 
See https://www.reddit.com/r/docker/comments/xwfm08/why_do_i_need_to_specify_host0000_when_running_a/