### PR TITLE
:bug: Fix condition for create-release job to run

### DIFF
--- a/.github/workflows/cicd_base.yml
+++ b/.github/workflows/cicd_base.yml
@@ -1,4 +1,4 @@
-name: CI/CD Base Deployment
+name: 🧱 CI/CD Base Deployment
 
 on:
   workflow_call:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,11 @@
-name: Deployment 
+name: 🚀 Deployment 
 
 on:
   push:
+    branches: [ master ]
+  pull_request:
+    types: [ closed ]
+    branches: [ master ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Prd deployments are not triggering off of merged release PRs

The `create-release` job is always skipped bc the trigger for the workflow is on push events. In push events, the github.pull_request object is empty. Added the pull_request trigger to make sure the create-release job starts on release PR merge into master branch